### PR TITLE
Redesign async upload

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-semver.*]
 ignore_missing_imports = True
+
+[mypy-aiohttp.*]
+ignore_missing_imports = True

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -265,17 +265,16 @@ async def upload_rows(
     async with aiohttp.ClientSession() as session:
         upload_tasks = []
         first_upload = True
-        import time
-
+        # import time
         # checkpoint = time.time()
         while len(upload_queue) > 0:
-            x = time.time()
+            # x = time.time()
             # print(
             #     f"time since last checkpoint {x - checkpoint}, "
             #     f"queue length: {len(upload_queue)}, "
             #     f"num_upload_tasks: {len(upload_tasks)}"
             # )
-            checkpoint = x
+            # checkpoint = x
             payload = [upload_queue.popleft() for _ in range(len(upload_queue))]
             upload_tasks.append(
                 asyncio.create_task(

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -222,7 +222,7 @@ async def validate_rows(
     :param rows_per_payload: max number of rows in each payload
     :param existing_ids: set of row IDs that were already uploaded, defaults to None
     """
-    existing_ids: Set[str] = set() if existing_ids is None else set([str(x) for x in existing_ids])
+    existing_ids_: Set[str] = set() if existing_ids is None else set([str(x) for x in existing_ids])
     seen_ids: Set[str] = set()
 
     dataset = init_dataset_from_filepath(dataset_filepath)
@@ -234,7 +234,7 @@ async def validate_rows(
         while len(upload_queue) >= rows_per_payload:
             await asyncio.sleep(0)
         row, row_id, warnings = validate_and_process_record(
-            record, schema, seen_ids, existing_ids, columns
+            record, schema, seen_ids, existing_ids_, columns
         )
         update_log_with_warnings(log, row_id, warnings)
         # row and row ID both present, i.e. row will be uploaded

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -2,8 +2,6 @@
 Helper functions for processing and uploading dataset rows
 """
 import asyncio
-import threading
-import queue
 from collections import deque
 import aiohttp
 import click
@@ -221,6 +219,7 @@ async def validate_rows(
     :param schema: a validated schema
     :param log: log dict to add warnings to
     :param upload_queue: queue to place validated rows in for upload
+    :param rows_per_payload: max number of rows in each payload
     :param existing_ids: set of row IDs that were already uploaded, defaults to None
     """
     existing_ids: Set[str] = set() if existing_ids is None else set([str(x) for x in existing_ids])
@@ -331,7 +330,7 @@ async def upload_dataset(
     row_size = getsizeof(next(init_dataset_from_filepath(filepath).read_streaming_records()))
     rows_per_payload = int(payload_size * 1e6 / row_size)
 
-    upload_queue = deque()
+    upload_queue: deque = deque()
 
     producer = asyncio.create_task(
         validate_rows(


### PR DESCRIPTION
## Description 

Async upload is currently slowed down by our use of `queue.Queue` for our `upload_queue`  -- which is needed for synchronized thread behavior, which we don't really need, since only one thread reads/writes to the upload queue at any one time.

This PR switches the data structure for `upload_queue` to `collections.deque`. Moreover, rather than processing rows one at a time, and interleaving put / get operations, we rewrite the async processes to instead have:
1. the **validate, process, put on upload queue** process fill the queue to the max of `payload_size`, before giving up control to... 
2. the **construct and POST payload** process, which empties the upload queue completely, constructs the payload from its contents using a list comprehension, sends out the POST request before yielding control.

## Motivation and Context
See this issue: https://github.com/cleanlab/cleanlab-studio/issues/228#issuecomment-1185513914 for more context.

The cost for transferring rows from queue to payload (first putting them on queue, and then removing them) is ~0.53s per payload, which adds up to ~14s for the 100MB Tweets.csv.

## How has this been tested?

This works with 10MB Tweets, but fails with 100MB Tweets at the moment. More details in the next comment.