### PR TITLE
Tests for data type and feature type inference

### DIFF
--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -215,9 +215,9 @@ def infer_types(values: Collection[Any]) -> Tuple[DataType, FeatureType]:
             counts[DataType.string] += 1
         elif isinstance(v, float):
             counts[DataType.float] += 1
+        elif isinstance(v, bool):  # must come before int: isinstance(True, int) evaluates to True
+            counts[DataType.boolean] += 1
         elif isinstance(v, int):
-            counts[DataType.integer] += 1
-        elif isinstance(v, bool):
             counts[DataType.integer] += 1
         elif isinstance(v, decimal.Decimal):  # loading from JSONs can produce Decimal values
             counts[DataType.float] += 1

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -155,7 +155,7 @@ def get_validation_sample_size(values: Sized) -> int:
     return min(20, len(values))
 
 
-def _values_are_datetime(values: Collection[Any]) -> bool:
+def string_values_are_datetime(values: Collection[Any]) -> bool:
     try:
         # check for datetime first
         val_sample = random.sample(list(values), get_validation_sample_size(values))
@@ -168,7 +168,7 @@ def _values_are_datetime(values: Collection[Any]) -> bool:
     return True
 
 
-def _values_are_integers(values: Collection[Any]) -> bool:
+def string_values_are_integers(values: Collection[Any]) -> bool:
     try:
         val_sample = random.sample(list(values), get_validation_sample_size(values))
         for s in val_sample:
@@ -179,7 +179,7 @@ def _values_are_integers(values: Collection[Any]) -> bool:
     return True
 
 
-def _values_are_floats(values: Collection[Any]) -> bool:
+def string_values_are_floats(values: Collection[Any]) -> bool:
     try:
         val_sample = random.sample(list(values), get_validation_sample_size(values))
         for s in val_sample:
@@ -228,14 +228,14 @@ def infer_types(values: Collection[Any]) -> Tuple[DataType, FeatureType]:
     max_count_type = max(ratios, key=lambda k: ratios[k])
 
     # preliminary check: ints/floats may be loaded as strings
-    if max_count_type:
-        if _values_are_integers(values):
+    if max_count_type == DataType.string:
+        if string_values_are_integers(values):
             max_count_type = DataType.integer
-        elif _values_are_floats(values):
+        elif string_values_are_floats(values):
             max_count_type = DataType.float
 
     if max_count_type == DataType.string:
-        if _values_are_datetime(values):
+        if string_values_are_datetime(values):
             return DataType.string, FeatureType.datetime
         # is string type
         if ratio_unique >= ID_RATIO_THRESHOLD:

--- a/tests/schema_generation/test_infer_boolean_data_type.py
+++ b/tests/schema_generation/test_infer_boolean_data_type.py
@@ -1,0 +1,19 @@
+from cleanlab_cli.dataset import DataType, FeatureType
+from cleanlab_cli.dataset.schema_helpers import infer_types
+
+
+class TestInferBooleanDataType:
+    def test_infer_boolean(self):
+        combos = [
+            [True, False],
+            # ['yes', 'no'],
+            # ['t', 'f'],
+            # [1, 0],
+            # [1.0, 0.0]
+        ]
+        # we do not look out for these non-boolean cases explicitly at the moment
+        for combo in combos:
+            values = [combo[i % 2] for i in range(1000)]
+            data_type, feature_type = infer_types(values)
+            assert data_type == DataType.boolean
+            assert feature_type == FeatureType.boolean

--- a/tests/schema_generation/test_infer_float_data_type.py
+++ b/tests/schema_generation/test_infer_float_data_type.py
@@ -1,0 +1,15 @@
+from cleanlab_cli.dataset import DataType, FeatureType
+from cleanlab_cli.dataset.schema_helpers import infer_types
+from tests.schema_generation.utils import cast_to_strings
+
+
+class TestInferFloatDataType:
+    def test_infer_float_numeric(self):
+        values = [float(i**2) for i in range(1000)]
+        data_type, feature_type = infer_types(values)
+        assert data_type == DataType.float
+        assert feature_type == FeatureType.numeric
+
+        data_type, feature_type = infer_types(cast_to_strings(values))
+        assert data_type == DataType.float
+        assert feature_type == FeatureType.numeric

--- a/tests/schema_generation/test_infer_integer_data_type.py
+++ b/tests/schema_generation/test_infer_integer_data_type.py
@@ -1,0 +1,42 @@
+import random
+from typing import List, Any
+
+from cleanlab_cli.dataset import DataType, FeatureType
+from cleanlab_cli.dataset.schema_helpers import infer_types
+
+
+def cast_to_strings(values: List[Any]):
+    return [str(x) for x in values]
+
+
+class TestInferIntegerDataType:
+    def test_infer_integer_identifier(self):
+        values = [i for i in range(1000)]
+        data_type, feature_type = infer_types(values)
+        assert data_type == DataType.integer
+        assert feature_type == FeatureType.identifier
+
+        data_type, feature_type = infer_types(cast_to_strings(values))
+        assert data_type == DataType.integer
+        assert feature_type == FeatureType.identifier
+
+    def test_infer_integer_categorical(self):
+        values = [i % 10 for i in range(1000)]
+        data_type, feature_type = infer_types(values)
+        assert data_type == DataType.integer
+        assert feature_type == FeatureType.categorical
+
+        data_type, feature_type = infer_types(cast_to_strings(values))
+        assert data_type == DataType.integer
+        assert feature_type == FeatureType.categorical
+
+    def test_infer_integer_numeric(self):
+        random.seed(43)
+        values = [random.randrange(0, 100) for _ in range(100)]
+        data_type, feature_type = infer_types(values)
+        assert data_type == DataType.integer
+        assert feature_type == FeatureType.numeric
+
+        data_type, feature_type = infer_types(cast_to_strings(values))
+        assert data_type == DataType.integer
+        assert feature_type == FeatureType.numeric

--- a/tests/schema_generation/test_infer_integer_data_type.py
+++ b/tests/schema_generation/test_infer_integer_data_type.py
@@ -1,12 +1,8 @@
 import random
-from typing import List, Any
 
 from cleanlab_cli.dataset import DataType, FeatureType
 from cleanlab_cli.dataset.schema_helpers import infer_types
-
-
-def cast_to_strings(values: List[Any]):
-    return [str(x) for x in values]
+from tests.schema_generation.utils import cast_to_strings
 
 
 class TestInferIntegerDataType:

--- a/tests/schema_generation/test_infer_string_data_type.py
+++ b/tests/schema_generation/test_infer_string_data_type.py
@@ -1,0 +1,57 @@
+import random
+import uuid
+from datetime import datetime, timedelta
+
+from cleanlab_cli.dataset import DataType, FeatureType
+from cleanlab_cli.dataset.schema_helpers import infer_types
+
+
+class TestInferStringDataType:
+    def test_infer_string_identifier(self):
+        values = [uuid.uuid4().hex for _ in range(1000)]
+        data_type, feature_type = infer_types(values)
+        assert data_type == DataType.string
+        assert feature_type == FeatureType.identifier
+
+    def test_infer_string_categorical(self):
+        values = [["alpha", "beta", "gamma", "delta"][i % 4] for i in range(1000)]
+        data_type, feature_type = infer_types(values)
+        assert data_type == DataType.string
+        assert feature_type == FeatureType.categorical
+
+    def test_infer_string_datetime(self):
+        datetime_now = datetime.now()
+        datetime_values = [
+            datetime_now
+            + timedelta(
+                days=random.randint(1, 100),
+                hours=random.randint(1, 24),
+                minutes=random.randint(1, 60),
+                seconds=random.randint(1, 60),
+            )
+            for _ in range(1000)
+        ]
+        datetime_formats = ["%H:%M:%S", "%m/%d/%Y", "%d %b %Y", "%d %b %Y %H:%M:%S"]
+        for datetime_format in datetime_formats:
+            formatted_datetime_values = [x.strftime(datetime_format) for x in datetime_values]
+            data_type, feature_type = infer_types(formatted_datetime_values)
+            assert data_type == DataType.string
+            assert feature_type == FeatureType.datetime
+
+    def test_infer_string_text(self):
+        lorem_ipsum = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+        et dolore magna aliqua. Id diam maecenas ultricies mi eget mauris pharetra et. Mi sit amet mauris commodo
+        quis imperdiet. Mi ipsum faucibus vitae aliquet nec ullamcorper. Urna cursus eget nunc scelerisque viverra
+        mauris in aliquam. Pulvinar neque laoreet suspendisse interdum consectetur libero id faucibus nisl.
+        Sollicitudin tempor id eu nisl nunc mi ipsum faucibus vitae.
+        """
+        lorem_len = len(lorem_ipsum)
+        texts = []
+        for _ in range(1000):
+            start_idx = random.randint(1, lorem_len)
+            end_idx = random.randint(start_idx, lorem_len)
+            texts.append(lorem_ipsum[start_idx:end_idx])
+        data_type, feature_type = infer_types(texts)
+        assert data_type == DataType.string
+        assert feature_type == FeatureType.text

--- a/tests/schema_generation/utils.py
+++ b/tests/schema_generation/utils.py
@@ -1,0 +1,5 @@
+from typing import List, Any
+
+
+def cast_to_strings(values: List[Any]):
+    return [str(x) for x in values]


### PR DESCRIPTION
Adds tests for inferring data types and feature types from a collection of values using the `infer_types` method.

Fixes two bugs:
- Extra check for whether ints/floats were loaded as strings should only occur when the majority data type is `string`
- Booleans were incorrectly recognized as integers