### PR TITLE
Fix regex for extracting floats/ints from strings + add more test cases

### DIFF
--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -557,14 +557,28 @@ def save_warning_log(warning_log: WarningLog, filename: str) -> None:
 
 def extract_float_string(column_value: str) -> str:
     """
-    Floating point: Decimal number containing a decimal point, optionally preceded by a + or - sign
-    and optionally followed by the e or E character and a decimal number.
+    Floating point: Decimal number containing a decimal point, optionally preceded by a + or - sign,
+    and then optionally preceded by a currency symbol.
+    Optionally followed by the e or E character and a decimal number, and optionally ended with a % symbol.
+
+    The extracted string should include only the value (i.e. includes decimals and E notation), and no other symbols.
+    If a - sign precedes the value string, it is preserved in the return value.
 
     Reference: https://docs.python.org/3/library/re.html#simulating-scanf
     """
-    float_regex_pattern = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
-    float_value = re.search(float_regex_pattern, column_value)
-    return float_value.group(0) if float_value else ""
+    float_regex_pattern = r"^([+-]?)[$€£]?((\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)[%]?$"
+    match = re.search(float_regex_pattern, column_value)
+    if match:
+        group_1 = match.group(1)
+        if group_1 in ["+", "-"]:
+            if group_1 == "-":
+                return f"-{match.group(2)}"
+            else:
+                return match.group(2)
+        else:
+            return match.group(2)
+    else:
+        return ""
 
 
 def process_dataset(

--- a/tests/unit/test_extract_float_string.py
+++ b/tests/unit/test_extract_float_string.py
@@ -1,15 +1,46 @@
 from cleanlab_cli.dataset import extract_float_string
 
+base_values = [180, 180.0, 180.5, 1.8e9]
+
 
 class TestExtractFloatString:
-    def test_percentage_string(self):
-        assert extract_float_string("180.5%") == "180.5"
+    def test_base_value_strings(self):
+        for v in base_values:
+            assert extract_float_string(str(v)) == str(v)
 
-    def test_dollar_string(self):
-        assert extract_float_string("$180.5") == "180.5"
+    def test_percentage_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"{v}%") == str(v)
 
-    def test_float_string(self):
-        assert extract_float_string("180.5") == "180.5"
+    def test_dollar_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"${v}") == str(v)
 
-    def test_invalid_string(self):
-        assert extract_float_string("c2ab3") == ""
+    def test_positive_sign_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"+{v}") == str(v)
+
+    def test_negative_sign_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"-{v}") == f"-{v}"
+
+    def test_positive_dollar_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"+${v}") == str(v)
+
+    def test_negative_dollar_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"-${v}") == f"-{v}"
+
+    def test_positive_percentage_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"+{v}%") == str(v)
+
+    def test_negative_percentage_strings(self):
+        for v in base_values:
+            assert extract_float_string(f"-{v}%") == f"-{v}"
+
+    def test_invalid_strings(self):
+        invalid_strings = ["2c", "2c2", "c2c", "c2"]
+        for s in invalid_strings:
+            assert extract_float_string(s) == ""


### PR DESCRIPTION
This PR fixes the regex in `extract_float_string`, which resolves the following issues:

- Negative signs were being dropped, e.g. `extract_float_string("-180")` returned `"180"` instead of `"-180"`
- Resolves #33 (we were not able to handle $ and % in strings)
- Invalid strings like `extract_float_string("c2ab3")` returned `"2"` and `extract_float_string("cc982")` returned `"982"`, instead of `""`

Adds a fuller test suite for `extract_float_string`. All tests pass now.