### PR TITLE
Skip checking version compat for "version" command

### DIFF
--- a/cleanlab_studio/cli/main.py
+++ b/cleanlab_studio/cli/main.py
@@ -13,7 +13,7 @@ from cleanlab_studio.version import __version__
 
 @click.group()
 @click.pass_context
-def cli(ctx) -> None:
+def cli(ctx: click.Context) -> None:
     if ctx.invoked_subcommand == "version":
         return  # avoid RTT / dependence on API to get client version
     CleanlabSettings.init_cleanlab_settings()

--- a/cleanlab_studio/cli/main.py
+++ b/cleanlab_studio/cli/main.py
@@ -12,7 +12,10 @@ from cleanlab_studio.version import __version__
 
 
 @click.group()
-def cli() -> None:
+@click.pass_context
+def cli(ctx) -> None:
+    if ctx.invoked_subcommand == "version":
+        return  # avoid RTT / dependence on API to get client version
     CleanlabSettings.init_cleanlab_settings()
     valid_version = api_service.check_client_version()
     if not valid_version:


### PR DESCRIPTION
This makes `cleanlab version` faster and also makes it avoid relying on our API. We might ask users to run `cleanlab version` to help us with debugging, and so this command should be as robust as possible.