### PR TITLE
Parallelize S3 uploads

### DIFF
--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -20,7 +20,7 @@ from cleanlab_studio.cli.types import JSONDict, IDType, Modality
 base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
 
 
-MAX_PARALLEL_UPLOADS = 100  # XXX choose this dynamically?
+MAX_PARALLEL_UPLOADS = 30  # XXX choose this dynamically?
 
 
 def _construct_headers(

--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -6,7 +6,7 @@ import gzip
 import json
 import os
 import asyncio
-from typing import List, Any, Optional
+from typing import List, Any, Optional, Tuple
 
 import aiohttp
 import requests
@@ -106,7 +106,7 @@ async def upload_rows_async(
         sem = asyncio.Semaphore(MAX_PARALLEL_UPLOADS)
         cancelled = False
 
-        async def post_file(original_filepath, absolute_filepath):
+        async def post_file(original_filepath: str, absolute_filepath: str) -> Tuple[Optional[bool], str]:
             async with sem:
                 # note: we pass in the path and we don't open the file until we
                 # get in here, so we don't have tons of concurrently opened

--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -20,7 +20,7 @@ from cleanlab_studio.cli.types import JSONDict, IDType, Modality
 base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
 
 
-MAX_PARALLEL_UPLOADS = 30  # XXX choose this dynamically?
+MAX_PARALLEL_UPLOADS = 32  # XXX choose this dynamically?
 
 
 def _construct_headers(


### PR DESCRIPTION
With the Snacks dataset (848 MB, 6745 images) for example, this change brings the upload time down from 12 minutes to 1 minute.