### PR TITLE
check_dataset_limit for image datasets

### DIFF
--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -241,10 +241,12 @@ def check_client_version() -> bool:
     return valid
 
 
-def check_dataset_limit(api_key: str, file_size: int, show_warning: bool = False) -> JSONDict:
+def check_dataset_limit(
+    api_key: str, file_size: int, image_dataset: bool = False, show_warning: bool = False
+) -> JSONDict:
     res = requests.post(
         base_url + "/check_dataset_limit",
-        json=dict(file_size=file_size),
+        json=dict(file_size=file_size, image_dataset=image_dataset),
         headers=_construct_headers(api_key),
     )
     handle_api_error(res, show_warning=show_warning)

--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -619,5 +619,8 @@ def get_image_dataset_size(dataset_filepath: str, filepath_column: str) -> int:
     """Returns total image dataset size by summing file sizes of each image"""
     dataset = init_dataset_from_filepath(dataset_filepath)
     return sum(
-        [get_file_size(record[filepath_column]) for record in dataset.read_streaming_records()]
+        [
+            get_file_size(filepath=record[filepath_column], ignore_missing_files=True)
+            for record in dataset.read_streaming_records()
+        ]
     )

--- a/cleanlab_studio/cli/util.py
+++ b/cleanlab_studio/cli/util.py
@@ -37,7 +37,7 @@ def get_filename(filepath: str) -> str:
     return os.path.split(filepath)[-1]
 
 
-def get_file_size(filepath: str, ignore_missing_files: bool) -> int:
+def get_file_size(filepath: str, ignore_missing_files: bool = False) -> int:
     if ignore_missing_files:
         try:
             return os.path.getsize(filepath)

--- a/cleanlab_studio/cli/util.py
+++ b/cleanlab_studio/cli/util.py
@@ -41,7 +41,7 @@ def get_file_size(filepath: str, ignore_missing_files: bool = False) -> int:
     if ignore_missing_files:
         try:
             return os.path.getsize(filepath)
-        except FileNotFoundError:
+        except IOError:
             return 0
     return os.path.getsize(filepath)
 

--- a/cleanlab_studio/cli/util.py
+++ b/cleanlab_studio/cli/util.py
@@ -37,7 +37,12 @@ def get_filename(filepath: str) -> str:
     return os.path.split(filepath)[-1]
 
 
-def get_file_size(filepath: str) -> int:
+def get_file_size(filepath: str, ignore_missing_files: bool) -> int:
+    if ignore_missing_files:
+        try:
+            return os.path.getsize(filepath)
+        except FileNotFoundError:
+            return 0
     return os.path.getsize(filepath)
 
 


### PR DESCRIPTION
Part of the solution for https://github.com/cleanlab/cleanlab-studio-integration/issues/751:

This limits limits max uploaded dataset size for image datasets, similar to how we check for text/tabular datasets. Instead of checking one dataset file size, we sum the sizes of all files in the upload. (*Value is set to 5GB for now)

![Screen Shot 2022-11-30 at 7 37 37 PM](https://user-images.githubusercontent.com/13542329/204937822-e3217b6e-aa57-4ed0-9ad9-b398191ce9e2.png)
