### PR TITLE
Fix: Excel timestamp handling

### DIFF
--- a/cleanlab_studio/cli/classes/excel_dataset.py
+++ b/cleanlab_studio/cli/classes/excel_dataset.py
@@ -54,7 +54,6 @@ class ExcelDataset(Dataset):
         :return: preprocessed record value
         """
         if isinstance(record_value, (datetime.time, datetime.datetime, pd.Timestamp)):
-            print(f"preprocessing datetime val: {record_value}")
             return record_value.isoformat()
 
         return record_value

--- a/cleanlab_studio/cli/classes/excel_dataset.py
+++ b/cleanlab_studio/cli/classes/excel_dataset.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import List, Generator, Any
 
 from cleanlab_studio.cli.classes.dataset import Dataset
@@ -10,13 +11,13 @@ from cleanlab_studio.cli.types import RecordType
 class ExcelDataset(Dataset):
     def read_streaming_records(self) -> Generator[RecordType, None, None]:
         for r in pyexcel.iget_records(file_name=self.filepath):
-            yield r
+            yield self._preprocess_record(r)
 
     def read_streaming_values(self) -> Generator[List[Any], None, None]:
         stream = pyexcel.iget_array(file_name=self.filepath)
         next(stream)  # skip header row
         for r in stream:
-            yield r
+            yield self._preprocess_value(r)
 
     def read_file_as_dataframe(self) -> pd.DataFrame:
         return pd.read_excel(self.filepath, keep_default_na=True)
@@ -24,3 +25,27 @@ class ExcelDataset(Dataset):
     def get_columns(self) -> List[str]:
         stream = pyexcel.iget_array(file_name=self.filepath)
         return [str(col) for col in next(stream)]
+
+    def _preprocess_record(self, record: RecordType) -> RecordType:
+        """Preprocesses record.
+
+        :param record: record to preprocess
+        :return: preprocess record
+        """
+        return {
+            record_key: self._preprocess_value(record_value)
+            for record_key, record_value in record.items()
+        }
+
+    def _preprocess_value(self, record_value: Any) -> Any:
+        """Preprocesses record value.
+        Operations performed:
+            - Cast datetimes to strings
+
+        :param record_value: record value to preprocess
+        :return: preprocessed record value
+        """
+        if isinstance(record_value, (datetime.time, datetime.datetime, pd.Timestamp)):
+            return record_value.isoformat()
+
+        return record_value

--- a/cleanlab_studio/cli/classes/excel_dataset.py
+++ b/cleanlab_studio/cli/classes/excel_dataset.py
@@ -17,7 +17,7 @@ class ExcelDataset(Dataset):
         stream = pyexcel.iget_array(file_name=self.filepath)
         next(stream)  # skip header row
         for r in stream:
-            yield self._preprocess_value(r)
+            yield self._preprocess_values(r)
 
     def read_file_as_dataframe(self) -> pd.DataFrame:
         return pd.read_excel(self.filepath, keep_default_na=True)
@@ -37,6 +37,14 @@ class ExcelDataset(Dataset):
             for record_key, record_value in record.items()
         }
 
+    def _preprocess_values(self, values: List[Any]) -> List[Any]:
+        """Preprocesses values.
+
+        :param values: values to preprocess
+        :return: preprocess values
+        """
+        return [self._preprocess_value(value) for value in values]
+
     def _preprocess_value(self, record_value: Any) -> Any:
         """Preprocesses record value.
         Operations performed:
@@ -46,6 +54,7 @@ class ExcelDataset(Dataset):
         :return: preprocessed record value
         """
         if isinstance(record_value, (datetime.time, datetime.datetime, pd.Timestamp)):
+            print(f"preprocessing datetime val: {record_value}")
             return record_value.isoformat()
 
         return record_value


### PR DESCRIPTION
- convert timestamps to strings when loading ExcelDatasets

Tested with [bad.xslx](https://github.com/cleanlab/cleanlab-studio-integration/files/9675451/bad.xlsx) and [bad_numbers.xslx](https://github.com/cleanlab/cleanlab-studio-integration/files/9675408/bad_numbers.xlsx) and running:
```python
from cleanlab_studio.cli.dataset.schema_helpers import *
print(propose_schema('bad.xlsx'))
```