### PR TITLE
check_dataset_limit by dataset modality

### DIFF
--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -242,11 +242,11 @@ def check_client_version() -> bool:
 
 
 def check_dataset_limit(
-    api_key: str, file_size: int, image_dataset: bool = False, show_warning: bool = False
+    api_key: str, file_size: int, modality: str, show_warning: bool = False
 ) -> JSONDict:
     res = requests.post(
         base_url + "/check_dataset_limit",
-        json=dict(file_size=file_size, image_dataset=image_dataset),
+        json=dict(file_size=file_size, modality=modality),
         headers=_construct_headers(api_key),
     )
     handle_api_error(res, show_warning=show_warning)

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
Instead of `check_dataset_limit` only checking whether or not the dataset is an image dataset, it sends the actual modality to the backend (i.e. text, tabular, image)