### PR TITLE
Hotfix: json dataset parsing

### DIFF
--- a/cleanlab_studio/cli/classes/json_dataset.py
+++ b/cleanlab_studio/cli/classes/json_dataset.py
@@ -10,12 +10,12 @@ from cleanlab_studio.cli.types import RecordType
 class JsonDataset(Dataset):
     def read_streaming_records(self) -> Generator[RecordType, None, None]:
         with open(self.filepath, "rb") as f:
-            for r in ijson.items(f, "item"):
+            for _, r in ijson.kvitems(f, ""):
                 yield r
 
     def read_streaming_values(self) -> Generator[List[Any], None, None]:
         with open(self.filepath, "rb") as f:
-            for r in ijson.items(f, "item"):
+            for _, r in ijson.kvitems(f, ""):
                 yield r.values()
 
     def read_file_as_dataframe(self) -> pd.DataFrame:


### PR DESCRIPTION
Previously, parsing a JSON dataset was entirely broken -- no rows were being read. Bug can be replicated using the following dataset and the instructions below:

```python
from cleanlab_studio.cli.classes.json_dataset import JsonDataset

assert len(JsonDataset(<path to Tweets_small.json>)) == 211
```

This should raise an assertion error on main but pass on this branch.