### PR TITLE
add relative path support to dataset record validation

### DIFF
--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -3,7 +3,7 @@ Helper functions for processing and uploading dataset rows
 """
 import asyncio
 import decimal
-import os
+import pathlib
 import queue
 import re
 import threading
@@ -81,7 +81,7 @@ def validate_and_process_record(
     schema: Schema,
     seen_ids: Set[str],
     existing_ids: Set[str],
-    base_directory: str = "",
+    base_directory: pathlib.Path = pathlib.Path(""),
 ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
     """
     Validate the row against the provided schema; generate warnings where issues are found
@@ -154,7 +154,7 @@ def validate_and_process_record(
                     )
             elif col_feature_type == FeatureType.filepath:
                 if schema.metadata.modality == Modality.image:
-                    absolute_path = os.path.join(base_directory, column_value)
+                    absolute_path = str(base_directory.joinpath(column_value))
                     if not image_file_exists(absolute_path, dataset_filepath):
                         msg, warn_type = (
                             f"{column_name}: unable to find file at specified filepath {absolute_path}. "

--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -3,6 +3,7 @@ Helper functions for processing and uploading dataset rows
 """
 import asyncio
 import decimal
+import os
 import queue
 import re
 import threading
@@ -80,6 +81,7 @@ def validate_and_process_record(
     schema: Schema,
     seen_ids: Set[str],
     existing_ids: Set[str],
+    base_directory: str = "",
 ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
     """
     Validate the row against the provided schema; generate warnings where issues are found
@@ -152,18 +154,19 @@ def validate_and_process_record(
                     )
             elif col_feature_type == FeatureType.filepath:
                 if schema.metadata.modality == Modality.image:
-                    if not image_file_exists(column_value, dataset_filepath):
+                    absolute_path = os.path.join(base_directory, column_value)
+                    if not image_file_exists(absolute_path, dataset_filepath):
                         msg, warn_type = (
-                            f"{column_name}: unable to find file at specified filepath {column_value}. "
+                            f"{column_name}: unable to find file at specified filepath {absolute_path}. "
                             f"Filepath must be absolute or relative to the directory containing your dataset file.",
                             ValidationWarning.MISSING_FILE,
                         )
                         warnings[warn_type].append(msg)
                         return None, row_id, warnings
                     else:
-                        if not image_file_readable(column_value, dataset_filepath):
+                        if not image_file_readable(absolute_path, dataset_filepath):
                             msg, warn_type = (
-                                f"{column_name}: could not open file at {column_value}.",
+                                f"{column_name}: could not open file at {absolute_path}.",
                                 ValidationWarning.UNREADABLE_FILE,
                             )
                             warnings[warn_type].append(msg)


### PR DESCRIPTION
## Description
Add a `base_directory` param to `validate_and_process_record` so that we can successfully validate datasets with relative filepaths.

## Context
We are adding support for simple image zip upload through the UI. Since we don't want to expose our internal storage organization to users, we want to write only the relative file path of an image to the dataset. The `validate_and_process_record` function is called on every row of a dataset created from the UI before saving the dataset. The validation in this function will fail if a file does not exist. We are updating it to take in a `base_directory` parameter and join that with the file path in the dataset record before checking that the file exists.

## How to Test
- Check that uploading a simple image zip dataset using these [frontend changes](https://github.com/cleanlab/cleanlab-studio-frontend/pull/277) and [backend changes](https://github.com/cleanlab/cleanlab-studio-backend/pull/236/) works properly
- Check that uploading an image dataset through the CLI still works