### PR TITLE
Hotfix: pin openpyxl version to 3.0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "jsonstreams>=0.6.0",
         "semver>=2.13.0",
         "Pillow>=9.2.0",
+        "openpyxl==3.0.10",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
https://github.com/pyexcel/pyexcel-xlsx/issues/52

`openpyxl-3.1.0` breaks `read_sheet`. Pinning to 3.0.10 fixes