### PR TITLE
add flag to disable file existence checks in validation

### DIFF
--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -82,7 +82,7 @@ def validate_and_process_record(
     seen_ids: Set[str],
     existing_ids: Set[str],
     base_directory: pathlib.Path = pathlib.Path(""),
-    disable_file_existence_check: bool = False,
+    disable_filepath_checks: bool = False,
 ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
     """
     Validate the row against the provided schema; generate warnings where issues are found
@@ -153,7 +153,7 @@ def validate_and_process_record(
                         ValidationWarning.TYPE_MISMATCH,
                     )
             elif col_feature_type == FeatureType.filepath:
-                if schema.metadata.modality == Modality.image and not disable_file_existence_check:
+                if schema.metadata.modality == Modality.image and not disable_filepath_checks:
                     image_filepath = get_image_filepath(base_directory, column_value)
                     if not image_file_exists(image_filepath):
                         msg, warn_type = (

--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -77,12 +77,12 @@ def convert_to_python_type(val: Any, data_type: DataType) -> Any:
 
 
 def validate_and_process_record(
-    dataset: Union[Dataset[IO[str]], Dataset[IO[bytes]]],
     record: RecordType,
     schema: Schema,
     seen_ids: Set[str],
     existing_ids: Set[str],
     base_directory: pathlib.Path = pathlib.Path(""),
+    disable_file_existence_check: bool = False,
 ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
     """
     Validate the row against the provided schema; generate warnings where issues are found
@@ -153,7 +153,7 @@ def validate_and_process_record(
                         ValidationWarning.TYPE_MISMATCH,
                     )
             elif col_feature_type == FeatureType.filepath:
-                if schema.metadata.modality == Modality.image:
+                if schema.metadata.modality == Modality.image and not disable_file_existence_check:
                     image_filepath = get_image_filepath(base_directory, column_value)
                     if not image_file_exists(image_filepath):
                         msg, warn_type = (
@@ -621,7 +621,7 @@ def process_dataset(
         dataset.read_streaming_records(), total=len(dataset), initial=0, leave=True, unit=" rows"
     ):
         row, row_id, warnings = validate_and_process_record(
-            dataset, record, schema, seen_ids, existing_ids, base_directory=dataset_dir
+            record, schema, seen_ids, existing_ids, base_directory=dataset_dir
         )
         update_log_with_warnings(log, row_id, warnings)
         # row and row ID both present, i.e. row will be uploaded

--- a/tests/row_processing/utils.py
+++ b/tests/row_processing/utils.py
@@ -22,7 +22,6 @@ def process_record_with_fields(
     record[ID_COLUMN] = "id"
     schema = initialize_schema_from_fields(fields)
     row, row_id, warnings = validate_and_process_record(
-        dataset=Dataset(filepath="dummy_filepath.csv"),
         schema=schema,
         record=record,
         seen_ids=set(),


### PR DESCRIPTION
### Description
Allow disabling of filepath existence/readability checks in `validate_and_process_record`. This will be used when uploading a dataset via ZIP file since we don't extract the ZIP file contents, so the `image_file_exists` and `image_file_readable` checks will fail.

### Testing
- Unit tests pass
- Tested w/ changes in https://github.com/cleanlab/cleanlab-studio-backend/pull/273 and https://github.com/cleanlab/cleanlab-studio-frontend/pull/277