### PR TITLE
externally hosted media upload support

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -20,3 +20,6 @@ ignore_missing_imports = True
 
 [mypy-PIL.*]
 ignore_missing_imports = True
+
+[mypy-validators.*]
+ignore_missing_imports = True

--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -7,16 +7,14 @@ import json
 import os
 import pathlib
 import asyncio
-from typing import IO, List, Any, Optional, Tuple, Union
+from typing import List, Any, Optional, Tuple
 
 import aiohttp
 import requests
 
 from cleanlab_studio.version import __version__
-from cleanlab_studio.cli.classes.dataset import Dataset
 from cleanlab_studio.cli.click_helpers import abort, warn, info
 from cleanlab_studio.cli.dataset.image_utils import get_image_filepath
-from cleanlab_studio.cli.dataset.schema_helpers import get_dataset_filepath_columns
 from cleanlab_studio.cli.dataset.schema_types import Schema
 from cleanlab_studio.cli.types import JSONDict, IDType, MEDIA_MODALITIES
 

--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -209,7 +209,7 @@ async def post_file(
     session: aiohttp.ClientSession,
     original_filepath: str,
     absolute_filepath: str,
-    post_data: Any,
+    post_data: JSONDict,
     sem: asyncio.Semaphore,
     cancelled: asyncio.Event,
 ) -> Tuple[Optional[bool], str]:
@@ -224,7 +224,6 @@ async def post_file(
     :cancelled: event that signals if upload should be cancelled
     """
     async with sem:
-        assert isinstance(post_data, dict)
         presigned_post = post_data["post"]
         # note: we pass in the path and we don't open the file until we
         # get in here, so we don't have tons of concurrently opened

--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -168,7 +168,7 @@ async def upload_files_for_filepath_column(
     sem = asyncio.Semaphore(MAX_PARALLEL_UPLOADS)
     cancelled = asyncio.Event()
     filepath_column_idx = columns.index(filepath_column)
-    filepaths = [row[filepath_column_idx] for row in rows]
+    filepaths: List[str] = [row[filepath_column_idx] for row in rows]
     dataset_dir: pathlib.Path = pathlib.Path(dataset_filepath).parent
     absolute_filepaths = [
         str(get_image_filepath(dataset_dir, row[filepath_column_idx])) for row in rows
@@ -186,7 +186,7 @@ async def upload_files_for_filepath_column(
                 session,
                 original_filepath,
                 absolute_filepath,
-                filepath_to_posts.get(original_filepath),
+                dict(filepath_to_posts[original_filepath]),
                 sem,
                 cancelled,
             )

--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -18,6 +18,7 @@ from cleanlab_studio.cli.dataset.image_utils import get_image_filepath
 from cleanlab_studio.cli.dataset.schema_helpers import get_dataset_filepath_columns
 from cleanlab_studio.cli.dataset.schema_types import Schema
 from cleanlab_studio.cli.types import JSONDict, IDType, Modality
+from cleanlab_studio.cli.util import init_dataset_from_filepath
 
 base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
 
@@ -92,7 +93,8 @@ async def upload_rows_async(
     rows: List[Any],
 ) -> None:
     modality = schema.metadata.modality
-    filepath_columns = get_dataset_filepath_columns(dataset_filepath, schema)
+    dataset = init_dataset_from_filepath(dataset_filepath)
+    filepath_columns = get_dataset_filepath_columns(dataset, schema)
     needs_media_upload = modality in [Modality.image] and filepath_columns
     columns = list(schema.fields.keys())
 

--- a/cleanlab_studio/cli/dataset/schema.py
+++ b/cleanlab_studio/cli/dataset/schema.py
@@ -86,7 +86,6 @@ def check_dataset_command(
         seen_ids=seen_ids,
         existing_ids=existing_ids,
         log=log,
-        dataset_dir=pathlib.Path(filepath).parent,
     )
 
     total_warnings = sum([len(log.get(warning_type)) for warning_type in ValidationWarning])

--- a/cleanlab_studio/cli/dataset/schema.py
+++ b/cleanlab_studio/cli/dataset/schema.py
@@ -1,11 +1,10 @@
 import pathlib
-from typing import Optional, Set, List, Sized, Iterable, cast
+from typing import Optional, Set
 
 import click
 
 from cleanlab_studio.cli.dataset.helpers import (
     get_id_column_if_undefined,
-    get_filepath_column_if_undefined,
 )
 from cleanlab_studio.cli.dataset.upload_helpers import process_dataset
 from cleanlab_studio.cli.dataset.schema_helpers import (
@@ -17,7 +16,7 @@ from cleanlab_studio.cli.dataset.schema_helpers import (
 from cleanlab_studio.cli.dataset import upload_helpers
 from cleanlab_studio.cli.decorators.previous_state import PreviousState
 from cleanlab_studio.cli.dataset.upload_types import ValidationWarning
-from cleanlab_studio.cli.types import CommandState, MODALITIES, Modality
+from cleanlab_studio.cli.types import CommandState, MODALITIES
 from cleanlab_studio.cli.util import get_filename, init_dataset_from_filepath
 from cleanlab_studio.cli.decorators import previous_state
 import json
@@ -130,11 +129,6 @@ def check_dataset_command(
     help=f"Dataset modality: {', '.join(MODALITIES)}",
 )
 @click.option(
-    "--filepath-column",
-    type=str,
-    help=f"If uploading an image dataset, specify the column containing the image filepaths.",
-)
-@click.option(
     "--name",
     type=str,
     help="Custom name for dataset",
@@ -146,7 +140,6 @@ def generate_schema_command(
     output: Optional[str],
     id_column: Optional[str],
     modality: Optional[str],
-    filepath_column: Optional[str],
     name: Optional[str],
 ) -> None:
     if filepath is None:
@@ -155,10 +148,6 @@ def generate_schema_command(
     dataset = init_dataset_from_filepath(filepath)
     columns = dataset.get_columns()
     id_column = get_id_column_if_undefined(id_column=id_column, columns=columns)
-    if modality == Modality.image.value:
-        filepath_column = get_filepath_column_if_undefined(
-            modality=modality, filepath_column=filepath_column, columns=columns
-        )
 
     command_state: CommandState = dict(
         command="generate schema",
@@ -167,7 +156,6 @@ def generate_schema_command(
             output=output,
             id_column=id_column,
             modality=modality,
-            filepath_column=filepath_column,
             name=name,
         ),
     )
@@ -179,7 +167,6 @@ def generate_schema_command(
         columns=columns,
         id_column=id_column,
         modality=modality,
-        filepath_column=filepath_column,
     )
     click.echo(json.dumps(proposed_schema.to_dict(), indent=2))
 

--- a/cleanlab_studio/cli/dataset/schema_helpers.py
+++ b/cleanlab_studio/cli/dataset/schema_helpers.py
@@ -23,7 +23,7 @@ from cleanlab_studio.cli.dataset.schema_types import (
     Schema,
 )
 from cleanlab_studio.cli.types import Modality
-from cleanlab_studio.cli.util import dump_json, init_dataset_from_filepath
+from cleanlab_studio.cli.util import dump_json
 from cleanlab_studio.errors import ColumnMismatchError, EmptyDatasetError
 from cleanlab_studio.version import MAX_SCHEMA_VERSION, MIN_SCHEMA_VERSION, SCHEMA_VERSION
 
@@ -173,13 +173,14 @@ def is_filepath(string: str, check_existing: bool = False) -> bool:
 
 def is_url(string: str, check_existing: bool = False) -> bool:
     try:
-        is_valid = validators.url(string)
-        assert isinstance(is_valid, bool)
+        validators.url(string)
         if check_existing:
             requests.head(string)
             return True
-        return is_valid
-    except:
+        return True
+    except validators.ValidationFailure:
+        return False
+    except requests.RequestException:
         return False
 
 

--- a/cleanlab_studio/cli/dataset/schema_helpers.py
+++ b/cleanlab_studio/cli/dataset/schema_helpers.py
@@ -172,16 +172,17 @@ def is_filepath(string: str, check_existing: bool = False) -> bool:
 
 
 def is_url(string: str, check_existing: bool = False) -> bool:
+    if not validators.url(string):
+        return False
+
     try:
-        validators.url(string)
         if check_existing:
             requests.head(string)
             return True
-        return True
-    except validators.ValidationFailure:
-        return False
     except requests.RequestException:
         return False
+
+    return True
 
 
 def get_validation_sample_size(values: Sized) -> int:

--- a/cleanlab_studio/cli/dataset/schema_helpers.py
+++ b/cleanlab_studio/cli/dataset/schema_helpers.py
@@ -337,6 +337,7 @@ def propose_schema(
         columns = dataset.get_columns()
 
     if modality is None:
+        # suggested modality can be set to a media modality on line 382
         if len(columns) > 5:
             modality = Modality.tabular.value
         else:

--- a/cleanlab_studio/cli/dataset/schema_helpers.py
+++ b/cleanlab_studio/cli/dataset/schema_helpers.py
@@ -164,19 +164,21 @@ def multiple_separate_words_detected(values: Collection[Any]) -> bool:
 
 
 def is_filepath(string: str, check_existing: bool = False) -> bool:
+    if pathlib.Path(string).suffix == "" or " " in string:
+        return False
     if check_existing:
         return pathlib.Path(string).exists()
-    return pathlib.Path(string).suffix != "" and " " not in string
+    return True
 
 
 def is_url(string: str, check_existing: bool = False) -> bool:
     try:
+        is_valid = validators.url(string)
+        assert isinstance(is_valid, bool)
         if check_existing:
             requests.head(string)
             return True
-        res = validators.url(string)
-        assert isinstance(res, bool)
-        return res
+        return is_valid
     except:
         return False
 

--- a/cleanlab_studio/cli/dataset/schema_helpers.py
+++ b/cleanlab_studio/cli/dataset/schema_helpers.py
@@ -146,6 +146,17 @@ def validate_schema(schema: Schema, columns: Collection[str]) -> None:
         if not has_text:
             raise ValueError("Dataset modality is text, but none of the fields is a text column.")
 
+    elif modality == Modality.image:
+        image_columns = [
+            col for col, spec in schema.fields.items() if spec.feature_type == FeatureType.image
+        ]
+        if not image_columns:
+            raise ValueError(
+                "Dataset modality is image, but none of the fields is an image column."
+            )
+        if len(image_columns) > 1:
+            raise ValueError("More than one image column in a dataset is not currently supported.")
+
 
 def multiple_separate_words_detected(values: Collection[Any]) -> bool:
     avg_num_words = sum([len(str(v).split()) for v in values]) / len(values)

--- a/cleanlab_studio/cli/dataset/schema_types.py
+++ b/cleanlab_studio/cli/dataset/schema_types.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Set, Optional, Union, Any
+from typing import Dict, List, Set, Optional, Any
 
 from cleanlab_studio.cli.types import Modality
 
@@ -13,7 +14,6 @@ class DataType(Enum):
     integer = "integer"
     float = "float"
     boolean = "boolean"
-    media = "media"
 
 
 class FeatureType(Enum):
@@ -32,6 +32,7 @@ DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
         FeatureType.categorical,
         FeatureType.datetime,
         FeatureType.identifier,
+        FeatureType.image,
     },
     DataType.integer: {
         FeatureType.categorical,
@@ -41,8 +42,10 @@ DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
     },
     DataType.float: {FeatureType.datetime, FeatureType.numeric},
     DataType.boolean: {FeatureType.boolean},
-    DataType.media: {FeatureType.image},
 }
+
+
+MEDIA_FEATURE_TYPES: List[FeatureType] = [FeatureType.image]
 
 
 @dataclass
@@ -51,7 +54,7 @@ class FieldSpecification:
     feature_type: FeatureType
 
     @staticmethod
-    def create(data_type: str, feature_type: str) -> "FieldSpecification":
+    def create(data_type: str, feature_type: str) -> FieldSpecification:
         data_type_ = DataType(data_type)
         feature_type_ = FeatureType(feature_type)
 
@@ -73,7 +76,7 @@ class SchemaMetadata:
     name: str
 
     @staticmethod
-    def create(id_column: str, modality: str, name: str) -> "SchemaMetadata":
+    def create(id_column: str, modality: str, name: str) -> SchemaMetadata:
         return SchemaMetadata(
             id_column=id_column,
             modality=Modality(modality),
@@ -97,7 +100,7 @@ class Schema:
     @staticmethod
     def create(
         metadata: SchemaMetadataDictType, fields: Dict[str, Dict[str, str]], version: str
-    ) -> "Schema":
+    ) -> Schema:
         fields_ = dict()
         for field, field_spec in fields.items():
             if not isinstance(field, str):
@@ -141,7 +144,7 @@ class Schema:
         return retval
 
     @classmethod
-    def from_dict(cls, schema_dict: Dict[str, Any]) -> "Schema":
+    def from_dict(cls, schema_dict: Dict[str, Any]) -> Schema:
         return Schema.create(
             metadata=schema_dict["metadata"],
             fields=schema_dict["fields"],
@@ -161,5 +164,4 @@ DATA_TYPES_TO_PYTHON_TYPES: Dict[DataType, type] = {
     DataType.float: float,
     DataType.integer: int,
     DataType.boolean: bool,
-    DataType.media: str,
 }

--- a/cleanlab_studio/cli/dataset/schema_types.py
+++ b/cleanlab_studio/cli/dataset/schema_types.py
@@ -13,6 +13,7 @@ class DataType(Enum):
     integer = "integer"
     float = "float"
     boolean = "boolean"
+    media = "media"
 
 
 class FeatureType(Enum):
@@ -22,7 +23,7 @@ class FeatureType(Enum):
     text = "text"
     boolean = "boolean"
     datetime = "datetime"
-    filepath = "filepath"
+    image = "image"
 
 
 DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
@@ -31,7 +32,6 @@ DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
         FeatureType.categorical,
         FeatureType.datetime,
         FeatureType.identifier,
-        FeatureType.filepath,
     },
     DataType.integer: {
         FeatureType.categorical,
@@ -41,6 +41,7 @@ DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
     },
     DataType.float: {FeatureType.datetime, FeatureType.numeric},
     DataType.boolean: {FeatureType.boolean},
+    DataType.media: {FeatureType.image},
 }
 
 
@@ -70,17 +71,13 @@ class SchemaMetadata:
     id_column: str
     modality: Modality
     name: str
-    filepath_column: Optional[str]
 
     @staticmethod
-    def create(
-        id_column: str, modality: str, name: str, filepath_column: Optional[str] = None
-    ) -> "SchemaMetadata":
+    def create(id_column: str, modality: str, name: str) -> "SchemaMetadata":
         return SchemaMetadata(
             id_column=id_column,
             modality=Modality(modality),
             name=name,
-            filepath_column=filepath_column,
         )
 
     def to_dict(self) -> SchemaMetadataDictType:
@@ -88,7 +85,6 @@ class SchemaMetadata:
             id_column=self.id_column,
             modality=self.modality.value,
             name=self.name,
-            filepath_column=self.filepath_column,
         )
 
 
@@ -123,10 +119,11 @@ class Schema:
         assert id_column is not None
         assert modality is not None
         assert name is not None
-        filepath_column: Optional[str] = metadata.get("filepath_column", None)
         return Schema(
             metadata=SchemaMetadata.create(
-                id_column=id_column, modality=modality, name=name, filepath_column=filepath_column
+                id_column=id_column,
+                modality=modality,
+                name=name,
             ),
             fields=fields_,
             version=version,
@@ -164,4 +161,5 @@ DATA_TYPES_TO_PYTHON_TYPES: Dict[DataType, type] = {
     DataType.float: float,
     DataType.integer: int,
     DataType.boolean: bool,
+    DataType.media: str,
 }

--- a/cleanlab_studio/cli/dataset/upload.py
+++ b/cleanlab_studio/cli/dataset/upload.py
@@ -132,7 +132,7 @@ def simple_image_upload(
             },
             fields={
                 "id": {"data_type": "string", "feature_type": "identifier"},
-                "path": {"data_type": "media", "feature_type": "image"},
+                "path": {"data_type": "string", "feature_type": "image"},
                 "label": {"data_type": "string", "feature_type": "categorical"},
             },
             version=SCHEMA_VERSION,

--- a/cleanlab_studio/cli/dataset/upload.py
+++ b/cleanlab_studio/cli/dataset/upload.py
@@ -129,11 +129,10 @@ def simple_image_upload(
                 "id_column": "id",
                 "modality": "image",
                 "name": os.path.basename(os.path.abspath(directory)),
-                "filepath_column": "path",
             },
             fields={
                 "id": {"data_type": "string", "feature_type": "identifier"},
-                "path": {"data_type": "string", "feature_type": "filepath"},
+                "path": {"data_type": "media", "feature_type": "image"},
                 "label": {"data_type": "string", "feature_type": "categorical"},
             },
             version=SCHEMA_VERSION,
@@ -186,11 +185,6 @@ def simple_image_upload(
     help=f"If uploading a new dataset without a schema, specify data modality: {', '.join(MODALITIES)}",
 )
 @click.option(
-    "--filepath-column",
-    type=str,
-    help=f"If uploading an image dataset, specify the column containing the image filepaths.",
-)
-@click.option(
     "--name",
     "-n",
     type=str,
@@ -212,7 +206,6 @@ def upload(
     schema: Optional[str],
     id_column: Optional[str],
     modality: Optional[str],
-    filepath_column: Optional[str],
     name: Optional[str],
     output: Optional[str],
     resume: Optional[bool],
@@ -306,13 +299,12 @@ def upload(
             modality = click.prompt(f"Specify your dataset modality ({', '.join(MODALITIES)})")
 
     id_column = get_id_column_if_undefined(id_column=id_column, columns=columns)
-    if modality == Modality.image.value:
-        filepath_column = get_filepath_column_if_undefined(
-            modality=modality, filepath_column=filepath_column, columns=columns
-        )
 
     prev_state.update_args(
-        dict(modality=modality, id_column=id_column, filepath_column=filepath_column)
+        dict(
+            modality=modality,
+            id_column=id_column,
+        )
     )
 
     ### Propose schema
@@ -322,7 +314,6 @@ def upload(
         columns=columns,
         id_column=id_column,
         modality=modality,
-        filepath_column=filepath_column,
     )
     log(json.dumps(proposed_schema.to_dict(), indent=2))
     info(f"No schema was provided. We propose the above schema based on your dataset.")

--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -153,8 +153,6 @@ def validate_and_process_record(
                         " parsable by pandas.Timestamp()",
                         ValidationWarning.TYPE_MISMATCH,
                     )
-            elif col_type == DataType.media:
-                row[column_name] = str(column_value)
             else:
                 if col_type == DataType.string:
                     row[column_name] = str(column_value)  # type coercion

--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -253,7 +253,6 @@ def echo_log_warnings(log: WarningLog) -> None:
 
 def validate_rows(
     dataset: Union[Dataset[IO[bytes]], Dataset[IO[str]]],
-    dataset_filepath: str,
     schema: Schema,
     log: WarningLog,
     upload_queue: "queue.Queue[Optional[List[Any]]]",
@@ -278,7 +277,6 @@ def validate_rows(
         existing_ids=existing_ids,
         log=log,
         upload_queue=upload_queue,
-        dataset_dir=pathlib.Path(dataset_filepath).parent,
     )
     upload_queue.put(None, block=True)
 
@@ -510,7 +508,6 @@ def upload_dataset(
         target=validate_rows,
         kwargs={
             "dataset": dataset,
-            "dataset_filepath": filepath,
             "schema": schema,
             "log": log,
             "upload_queue": upload_queue,
@@ -639,7 +636,6 @@ def process_dataset(
     seen_ids: Set[str],
     existing_ids: Set[str],
     log: WarningLog,
-    dataset_dir: pathlib.Path,
     upload_queue: Optional["queue.Queue[Optional[List[Any]]]"] = None,
 ) -> None:
     """

--- a/cleanlab_studio/cli/types.py
+++ b/cleanlab_studio/cli/types.py
@@ -12,6 +12,7 @@ class Modality(Enum):
 
 
 MODALITIES = [m.value for m in Modality]
+MEDIA_MODALITIES = [Modality.image]
 
 
 class DatasetFileExtension(Enum):

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "semver>=2.13.0",
         "Pillow>=9.2.0",
         "openpyxl==3.0.10",
+        "validators>=0.20.0",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
### Description
CLI changes to support uploading externally hosted media datasets.

### How should this be tested?
- Pull changes from `feat/external-media-upload` branch in `cleanlab-studio` and `cleanlab-studio-backend` repos
- Run studio app locally
- Try uploading dataset containing image urls from CLI (example: [dog_breeds_img_url_dataset.csv](https://github.com/cleanlab/cleanlab-studio/files/10798985/dog_breeds_img_url_dataset.csv))
- Make sure other image upload formats still work from CLI (simple image upload, csv manifest upload)
- Check if datasets were uploaded successfully in frontend (will need to pull from `feat/external-media-upload` branch in frontend repo for images to render properly when viewing project)