### PR TITLE
(easy) Fix: make get_dataset_file_extension case insensitive

### DIFF
--- a/cleanlab_studio/cli/util.py
+++ b/cleanlab_studio/cli/util.py
@@ -18,7 +18,7 @@ from cleanlab_studio.cli.types import (
 
 
 def get_dataset_file_extension(filename: str) -> DatasetFileExtension:
-    file_extension = pathlib.Path(filename).suffix
+    file_extension = pathlib.Path(filename).suffix.lower()
     return DatasetFileExtension(file_extension)
 
 


### PR DESCRIPTION
Currently uploading a dataset with a capitalized file extension fails https://github.com/cleanlab/cleanlab-studio-integration/issues/872

Closes cleanlab/cleanlab-studio-integration#872