### PR TITLE
Fix: throttle number of parallel uploads

### DIFF
--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -299,6 +299,8 @@ async def upload_rows(
     :param upload_queue: queue to get validated rows from
     :param rows_per_payload: number of rows to upload per payload/chunk
     """
+    NUM_PARALLEL_UPLOADS: int = 5
+    upload_sem = asyncio.Semaphore(NUM_PARALLEL_UPLOADS)
 
     async with aiohttp.ClientSession() as session:
         payload = []
@@ -320,6 +322,7 @@ async def upload_rows(
                             schema=schema,
                             rows=payload,
                             filepath_columns=filepath_columns,
+                            upload_sem=upload_sem,
                         )
                     )
                 )

--- a/cleanlab_studio/cli/dataset/upload_helpers.py
+++ b/cleanlab_studio/cli/dataset/upload_helpers.py
@@ -349,6 +349,7 @@ async def upload_rows(
                     schema=schema,
                     rows=payload,
                     filepath_columns=filepath_columns,
+                    upload_sem=upload_sem,
                 )
             )
 


### PR DESCRIPTION
@axl1313 was causing the backend to spill over its SQLAlchemy pool capacity by sending too many uploads in parallel. This change throttle the number of parallel uploads to prevent this from occurring.

This is a stop gap fix that will suffice until the data ingestion service is done.