### PR TITLE
Fix join bugs with Pandas DataFrames

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -129,10 +129,11 @@ class Studio:
             id_col = api.get_id_column(self._api_key, cleanset_id)
             cl_cols = self._download_cleanlab_columns(cleanset_id, project_id, label_column)
 
-            joined_ds = dataset.join(cl_cols, on=id_col, rsuffix="clean")
-            joined_ds["__cleanlab_final_label"] = cl_cols["cleanlab_clean_label"].where(
-                cl_cols["cleanlab_clean_label"] != "None", dataset[label_column]
+            joined_ds = dataset.join(cl_cols.set_index(id_col), on=id_col)
+            joined_ds["__cleanlab_final_label"] = joined_ds["cleanlab_clean_label"].where(
+                joined_ds["cleanlab_clean_label"] != "None", dataset[label_column]
             )
 
-            dataset[label_column] = joined_ds["__cleanlab_final_label"]
-            return dataset
+            corrected_ds = dataset.copy()
+            corrected_ds[label_column] = joined_ds["__cleanlab_final_label"]
+            return corrected_ds


### PR DESCRIPTION
df.join(other, on=...) always uses other's index, but uses the index column from df (an alternative is to set the index column for df as well, but that would mutate the df, which we want to preserve in this case). The rsuffix is not necessary: we don't expect there to be any other overlapping columns in cl_cols.

Later, when adding the __cleanlab_final_label column: we can't use cl_cols on the rhs of the assignment, because that DataFrame's index doesn't match the joined_ds, instead we should just use joined_ds.

Finally, we shouldn't mutate the DataFrame that was passed in, we should return a new DataFrame that has the corrections applied (later, we could expand the API to include an inplace=True kwarg).