### PR TITLE
backwards compatible change to support better simple zip schema handling

### DIFF
--- a/cleanlab_studio/cli/dataset/upload.py
+++ b/cleanlab_studio/cli/dataset/upload.py
@@ -64,7 +64,9 @@ def upload(
     else:
         schema = get_proposed_schema(api_key, upload_id)
         proceed_upload = None
-        if schema is not None:
+        if schema is None or schema.get("immutable", False):
+            proceed_upload = True
+        else:
             log(json.dumps(schema, indent=2))
             info(f"No schema was provided. We propose the above schema based on your dataset.")
 

--- a/cleanlab_studio/studio/upload.py
+++ b/cleanlab_studio/studio/upload.py
@@ -21,14 +21,14 @@ def upload_dataset(
     upload_id = upload_dataset_file(api_key, dataset_source)
     schema = get_proposed_schema(api_key, upload_id)
 
-    if schema is None and (
+    if (schema is None or schema.get("immutable", False)) and (
         schema_overrides is not None or modality is not None or id_column is not None
     ):
         print(
             "Warning: schema_overrides, modality, and id_column parameters will be ignored for simple zip uploads"
         )
 
-    if schema is not None:
+    if schema is not None and not schema.get("immutable", False):
         schema["metadata"]["name"] = dataset_source.dataset_name
         if schema_overrides is not None:
             for field in schema_overrides:


### PR DESCRIPTION
### Description
This change is meant to support changes in https://github.com/cleanlab/cleanlab-studio-data-ingestion/pull/35 while being backwards compatible

### Motivation and Context
Detailed context here: https://www.notion.so/cleanlab/1271-d1d13ce18eeb4d0083001276c65a8a29?pvs=4

### How should this be tested?
- Check that uploading simple zip, zip w/ metadata, and text/tabular datasets work using cli and python API with just these changes
- Check that uploading simple zip, zip w/ metadata, and text/tabular datasets work using cli and python API with this change + data ingestion changes

### Checklist

<!-- Check the relevant items -->

- [x] PR was tested and change works as expected
- [ ] Design decisions and approaches were documented in the PR Description
- [ ] Design documents on Notion have been updated
- [ ] Tests (unit / end-to-end) are created for new utility functions or user flows
