### PR TITLE
Feature: add support for creating projects through the python api

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@ https://cleanlab.github.io/cleanlab-studio/dev/bench/
    directory. Changes to the code are reflected automatically in the CLI.
 2. `Makefile` contains sample commands for quick installation and testing, though you will have to specify filepaths and
    API keys manually.
-3. Run `export CLEANLAB_API_BASE_URL="http://localhost:8500/api/cli/v0"` and `export CLEANLAB_API_UPLOAD_BASE_URL="http://localhost:8500/api/upload/v0"` so that API requests are made on your local
+3. Run `export CLEANLAB_API_BASE_URL="http://localhost:8500/api"` so that API requests are made on your local
    machine
 
 ## Formatting

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -199,7 +199,8 @@ def get_dataset_details(api_key: str, dataset_id: str) -> JSONDict:
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
-    return res.json()
+    dataset_details: JSONDict = res.json()
+    return dataset_details
 
 
 def clean_dataset(

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -9,10 +9,11 @@ from tqdm import tqdm
 from cleanlab_studio.internal.types import JSONDict
 from cleanlab_studio.version import __version__
 
-base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
-upload_base_url = os.environ.get(
-    "CLEANLAB_API_UPLOAD_BASE_URL", "https://api.cleanlab.ai/api/upload/v0"
-)
+base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api")
+cli_base_url = f"{base_url}/cli/v0"
+upload_base_url = f"{base_url}/upload/v0"
+dataset_base_url = f"{base_url}/datasets"
+project_base_url = f"{base_url}/projects"
 
 
 def _construct_headers(
@@ -42,7 +43,7 @@ def handle_api_error_from_json(res_json: JSONDict) -> None:
 
 def validate_api_key(api_key: str) -> bool:
     res = requests.get(
-        base_url + "/validate", json=dict(api_key=api_key), headers=_construct_headers(api_key)
+        cli_base_url + "/validate", json=dict(api_key=api_key), headers=_construct_headers(api_key)
     )
     handle_api_error(res)
     valid: bool = res.json()["valid"]
@@ -50,7 +51,7 @@ def validate_api_key(api_key: str) -> bool:
 
 
 def check_client_version() -> bool:
-    res = requests.post(base_url + "/check_client_version", json=dict(version=__version__))
+    res = requests.post(cli_base_url + "/check_client_version", json=dict(version=__version__))
     handle_api_error(res)
     valid: bool = res.json()["valid"]
     return valid
@@ -126,7 +127,7 @@ def get_dataset_id(api_key: str, upload_id: str) -> JSONDict:
 
 def get_project_of_cleanset(api_key: str, cleanset_id: str) -> str:
     res = requests.get(
-        base_url + f"/cleansets/{cleanset_id}/project",
+        cli_base_url + f"/cleansets/{cleanset_id}/project",
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
@@ -136,7 +137,7 @@ def get_project_of_cleanset(api_key: str, cleanset_id: str) -> str:
 
 def get_label_column_of_project(api_key: str, project_id: str) -> str:
     res = requests.get(
-        base_url + f"/projects/{project_id}/label_column",
+        cli_base_url + f"/projects/{project_id}/label_column",
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
@@ -154,7 +155,7 @@ def download_cleanlab_columns(api_key: str, cleanset_id: str, all: bool = False)
     :return: return (rows, id_column)
     """
     res = requests.get(
-        base_url + f"/cleansets/{cleanset_id}/columns?all={all}",
+        cli_base_url + f"/cleansets/{cleanset_id}/columns?all={all}",
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
@@ -164,7 +165,7 @@ def download_cleanlab_columns(api_key: str, cleanset_id: str, all: bool = False)
 
 def get_id_column(api_key: str, cleanset_id: str) -> str:
     res = requests.get(
-        base_url + f"/cleansets/{cleanset_id}/id_column",
+        cli_base_url + f"/cleansets/{cleanset_id}/id_column",
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
@@ -174,7 +175,7 @@ def get_id_column(api_key: str, cleanset_id: str) -> str:
 
 def get_dataset_of_project(api_key: str, project_id: str) -> str:
     res = requests.get(
-        base_url + f"/projects/{project_id}/dataset",
+        cli_base_url + f"/projects/{project_id}/dataset",
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
@@ -184,12 +185,50 @@ def get_dataset_of_project(api_key: str, project_id: str) -> str:
 
 def get_dataset_schema(api_key: str, dataset_id: str) -> JSONDict:
     res = requests.get(
-        base_url + f"/datasets/{dataset_id}/schema",
+        cli_base_url + f"/datasets/{dataset_id}/schema",
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
     schema: JSONDict = res.json()["schema"]
     return schema
+
+
+def get_dataset_details(api_key: str, dataset_id: str) -> JSONDict:
+    res = requests.get(
+        dataset_base_url + f"/details/{dataset_id}",
+        headers=_construct_headers(api_key),
+    )
+    handle_api_error(res)
+    return res.json()
+
+
+def clean_dataset(
+    api_key: str,
+    dataset_id: str,
+    project_name: str,
+    tasktype: str,
+    modality: str,
+    modeltype: str,
+    label_column: str,
+    feature_columns: List[str],
+    text_column: str,
+) -> str:
+    request_json = dict(
+        name=project_name,
+        dataset_id=dataset_id,
+        tasktype=tasktype,
+        modality=modality,
+        model_type=modeltype,
+        label_column=label_column,
+        feature_columns=feature_columns,
+        text_column=text_column,
+    )
+    res = requests.post(
+        project_base_url + f"/clean", headers=_construct_headers(api_key), json=request_json
+    )
+    handle_api_error(res)
+    project_id = res.json()["project_id"]
+    return str(project_id)
 
 
 def poll_progress(

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -211,7 +211,7 @@ def clean_dataset(
     modeltype: str,
     label_column: str,
     feature_columns: List[str],
-    text_column: str,
+    text_column: Optional[str],
 ) -> str:
     request_json = dict(
         name=project_name,

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -169,7 +169,7 @@ class Studio:
                     f"Invalid label column: {label_column}. Label column must have categorical feature type"
                 )
         else:
-            label_column = dataset_details["label_column_guess"]
+            label_column: str = dataset_details["label_column_guess"]
             print(f"Label column not supplied. Using best guess {label_column}")
 
         if feature_columns is not None and modality != "tabular":
@@ -178,8 +178,6 @@ class Studio:
             if modality == "tabular":
                 feature_columns = dataset_details["distinct_columns"]
                 print(f"Feature columns not supplied. Using all columns")
-            else:
-                feature_columns = []
 
         if text_column is not None:
             if modality != "text":
@@ -200,6 +198,6 @@ class Studio:
             modality=modality,
             modeltype=modeltype,
             label_column=label_column,
-            feature_columns=feature_columns,
+            feature_columns=feature_columns if feature_columns is not None else [],
             text_column=text_column,
         )

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -150,9 +150,9 @@ class Studio:
         dataset_id: str,
         project_name: str,
         *,
-        tasktype: Optional[str] = "multi-class",
+        tasktype: str = "multi-class",
         modality: Optional[str] = None,
-        modeltype: Optional[str] = "regular",
+        modeltype: str = "regular",
         label_column: Optional[str] = None,
         feature_columns: Optional[List[str]] = None,
         text_column: Optional[str] = None,
@@ -169,7 +169,7 @@ class Studio:
                     f"Invalid label column: {label_column}. Label column must have categorical feature type"
                 )
         else:
-            label_column: str = dataset_details["label_column_guess"]
+            label_column = str(dataset_details["label_column_guess"])
             print(f"Label column not supplied. Using best guess {label_column}")
 
         if feature_columns is not None and modality != "tabular":

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -149,10 +149,10 @@ class Studio:
         self,
         dataset_id: str,
         project_name: str,
-        modality: str,
+        modality: Literal["text", "tabular", "image"],
         *,
-        tasktype: str = "multi-class",
-        modeltype: str = "regular",
+        tasktype: Literal["multi-class", "multi-label"] = "multi-class",
+        modeltype: Literal["fast", "regular"] = "regular",
         label_column: Optional[str] = None,
         feature_columns: Optional[List[str]] = None,
         text_column: Optional[str] = None,


### PR DESCRIPTION
### Description
Adds support for creating projects through they Python API. User must supply dataset_id and project_name parameters. All other project fields are specified through optional kwargs. For fields that aren't supplied by the user, we make our best guess (similar to how the frontend supplies defaults)

### How to Test
- Test with backend changes in feat/python-api-project-creation
- Test that creating projects works for all modalities
- Try various combinations of user supplied and inferred project fields