### PR TITLE
Fix: make sure feature columns and label column don't overlap

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -186,10 +186,13 @@ class Studio:
             print(f"Label column not supplied. Using best guess {label_column}")
 
         if feature_columns is not None and modality != "tabular":
+            if label_column in feature_columns:
+                raise ValueError("Label column cannot be included in feature columns")
             raise ValueError("Feature columns supplied, but project modality is not tabular")
         if feature_columns is None:
             if modality == "tabular":
                 feature_columns = dataset_details["distinct_columns"]
+                feature_columns.remove(label_column)
                 print(f"Feature columns not supplied. Using all valid feature columns")
 
         if text_column is not None:


### PR DESCRIPTION
### Description
Creating a tabular project w/ the python api and using the default for feature columns will fail right now since the full list of distinct columns from dataset details contains the label column. This leads to a duplicate column error during training. This PR removes the label column from `feature_columns` in the default case and adds validation to raise an error if user supplied feature columns overlap with label column