### PR TITLE
add support for applying corrections to dataset w auto gen id

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -163,6 +163,11 @@ class Studio:
             corrected_ds = corrected_ds[joined_ds["action"] != "exclude"]
             return corrected_ds
 
+        else:
+            raise ValueError(
+                f"Provided unsupported dataset of type: {type(dataset)}. We currently support applying corrections to pandas or pyspark dataframes"
+            )
+
     def create_project(
         self,
         dataset_id: str,

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -113,11 +113,20 @@ class Studio:
 
             spark = dataset.sparkSession
             cl_cols_df = spark.createDataFrame(cl_cols)
-            # XXX this does not handle excluded columns correctly, because the API
-            # returns all rows regardless and doesn't let us distinguish between
-            # excluded and non-excluded rows
+            corrected_ds = dataset.alias("corrected_ds")
+            if id_col not in corrected_ds.columns:
+                from pyspark.sql.functions import (
+                    row_number,
+                    monotonically_increasing_id,
+                )
+                from pyspark.sql.window import Window
+
+                corrected_ds = corrected_ds.withColumn(
+                    id_col,
+                    row_number().over(Window.orderBy(monotonically_increasing_id())) - 1,
+                )
             both = cl_cols_df.select([id_col, "action", "cleanlab_clean_label"]).join(
-                dataset.select([id_col, label_column]),
+                corrected_ds.select([id_col, label_column]),
                 on=id_col,
                 how="left",
             )
@@ -133,16 +142,18 @@ class Studio:
             new_labels = final.select(
                 [id_col, "action", "__cleanlab_final_label"]
             ).withColumnRenamed("__cleanlab_final_label", label_column)
-            corrected_df = (
-                dataset.drop(label_column)
+            return (
+                corrected_ds.drop(label_column)
                 .join(new_labels, on=id_col, how="right")
                 .where(new_labels["action"] != "exclude")
                 .drop("action")
             )
-            return corrected_df
-
         elif isinstance(dataset, pd.DataFrame):
-            joined_ds = dataset.join(cl_cols.set_index(id_col), on=id_col)
+            joined_ds: pd.DataFrame
+            if id_col in dataset.columns:
+                joined_ds = dataset.join(cl_cols.set_index(id_col), on=id_col)
+            else:
+                joined_ds = dataset.join(cl_cols.set_index(id_col).sort_values(by=id_col))
             joined_ds["__cleanlab_final_label"] = joined_ds["cleanlab_clean_label"].where(
                 joined_ds["cleanlab_clean_label"] != "None", dataset[label_column]
             )

--- a/cleanlab_studio/studio/upload.py
+++ b/cleanlab_studio/studio/upload.py
@@ -24,8 +24,8 @@ def upload_dataset(
     if (schema is None or schema.get("immutable", False)) and (
         schema_overrides is not None or modality is not None or id_column is not None
     ):
-        print(
-            "Warning: schema_overrides, modality, and id_column parameters will be ignored for simple zip uploads"
+        raise ValueError(
+            "Schema_overrides, modality, and id_column parameters cannot be provided for simple zip uploads"
         )
 
     if schema is not None and not schema.get("immutable", False):


### PR DESCRIPTION
### Description
This PR adds support for running apply_corrections for a project with autogenerated ID columns for both pyspark and pandas dataframes. For projects created from datasets w/ autogenerated IDs we just join the corrected labels with the original dataframe in sorted order

### Motivation
We want to make autogenerated ID columns the default as we move away from requiring user specified ID columns

### Testing
For both pyspark and pandas datasets:
- Upload a dataset specifying id_column="cleanlab-autogenerate-id"
- Create a project and make some corrections. Also use exclude action for some rows
- Run `studio.apply_corrections()`. Check that rows w/ corrections have corrected label and rows w/ exclude action are properly excluded