### PR TITLE
add formatted docstrings for python api

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -20,3 +20,8 @@ jobs:
         run: python3 -m build
       - name: Release package
         run: twine upload dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN }} --verbose
+
+  update-docs:
+    needs: build-and-release-pypi-package
+    uses: cleanlab/cleanlab-studio-docs/.github/workflows/build_and_deploy.yml@main
+    secrets: inherit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,3 +152,7 @@ Every time the version number is incremented, these parts of the codebase need t
 
 1. `cleanlab_studio/version.py`
 2. `README.md`
+
+## Documentation Style Guide
+
+cleanlab-studio uses [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings ([example](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html))

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -155,4 +155,9 @@ Every time the version number is incremented, these parts of the codebase need t
 
 ## Documentation Style Guide
 
-cleanlab-studio uses [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings ([example](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html))
+We autogenerate documentation for the `studio` module from docstrings. In order for the generated docs to be formatted correctly, use [Google style](https://google.github.io/styleguide/pyguide.html#381-docstrings) docstrings ([example](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html))
+
+### Relative Link Formatting
+
+- To link to other functions in the `studio` module within a docstring, use the following format: `[link text](#method-function_name)`
+- To link to another page in Cleanlab Studio docs use `[link text](../../{path within cleanlab-studio-docs/docs})`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -160,4 +160,4 @@ We autogenerate documentation for the `studio` module from docstrings. In order 
 ### Relative Link Formatting
 
 - To link to other functions in the `studio` module within a docstring, use the following format: `[link text](#method-function_name)`
-- To link to another page in Cleanlab Studio docs use `[link text](../../{path within cleanlab-studio-docs/docs})`
+- To link to another page in Cleanlab Studio docs use `[link text](/{path within cleanlab-studio-docs/docs})`

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -104,7 +104,7 @@ class Studio:
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:
         """
-        Applies corrections from a Cleanlab Studio cleanset to your dataset. Corrections can be made by viewing your project in the Cleanlab Studio webapp (see [Cleanlab Studio web quickstart](../../guide/quickstart/web#review-the-errors)).
+        Applies corrections from a Cleanlab Studio cleanset to your dataset. Corrections can be made by viewing your project in the Cleanlab Studio webapp (see [Cleanlab Studio web quickstart](/guide/quickstart/web#review-the-errors)).
 
         Args:
             cleanset_id: ID of cleanset to apply corrections from.

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -13,7 +13,11 @@ except ImportError:
 
 from . import clean, upload
 from cleanlab_studio.internal.api import api
-from cleanlab_studio.internal.util import init_dataset_source, check_none, check_not_none
+from cleanlab_studio.internal.util import (
+    init_dataset_source,
+    check_none,
+    check_not_none,
+)
 from cleanlab_studio.internal.settings import CleanlabSettings
 from cleanlab_studio.internal.types import FieldSchemaDict
 
@@ -151,16 +155,18 @@ class Studio:
         """
         Creates a Cleanlab Studio project
 
-        :param dataset_id: ID of dataset to create project for
-        :param project_name: name for resulting project
-        :param modality: modality of project (i.e. text, tabular, image)
-        :keyword task_type: type of classification to perform (i.e. multi-class, multi-label)
-        :keyword model_type: type of model to train (i.e. fast, regular)
-        :keyword label_column: name of column in dataset containing labels (if not supplied, we'll make our best guess)
-        :keyword feature_columns: list of columns to use as features when training tabular modality project (if not supplied and modality is "tabular" we'll use all valid feature columns)
-        :keyword text_column: name of column containing the text to train text modality project on (if not supplied and modality is "text" we'll make our best guess)
+        Args:
+            dataset_id: ID of dataset to create project for
+            project_name: name for resulting project
+            modality: modality of project (i.e. text, tabular, image)
+            task_type: type of classification to perform (i.e. multi-class, multi-label)
+            model_type: type of model to train (i.e. fast, regular)
+            label_column: name of column in dataset containing labels (if not supplied, we'll make our best guess)
+            feature_columns: list of columns to use as features when training tabular modality project (if not supplied and modality is "tabular" we'll use all valid feature columns)
+            text_column: name of column containing the text to train text modality project on (if not supplied and modality is "text" we'll make our best guess)
 
-        :return: ID of project
+        Returns:
+            ID of project
         """
         dataset_details = api.get_dataset_details(self._api_key, dataset_id)
 
@@ -210,7 +216,8 @@ class Studio:
         """
         Polls for cleanset status. Blocks until cleanset is ready, there is a cleanset error, or `timeout` is exceeded
 
-        :return: True if cleanset is ready, False otherwise
+        Returns:
+            `True` if cleanset is ready, `False` otherwise
         """
         return clean.poll_cleanset_status(self._api_key, cleanset_id, timeout)
 

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -10,9 +10,9 @@ import pandas as pd
 try:
     import pyspark.sql
 
-    pyspark_exists = True
+    _pyspark_exists = True
 except ImportError:
-    pyspark_exists = False
+    _pyspark_exists = False
 
 from . import clean, upload
 from cleanlab_studio.internal.api import api
@@ -119,7 +119,7 @@ class Studio:
         label_column = api.get_label_column_of_project(self._api_key, project_id)
         id_col = api.get_id_column(self._api_key, cleanset_id)
         cl_cols = self.download_cleanlab_columns(cleanset_id, include_action=True)
-        if pyspark_exists and isinstance(dataset, pyspark.sql.DataFrame):
+        if _pyspark_exists and isinstance(dataset, pyspark.sql.DataFrame):
             from pyspark.sql.functions import udf
 
             spark = dataset.sparkSession

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -86,7 +86,7 @@ class Studio:
         Downloads Cleanlab columns for a cleanset.
 
         Args:
-            cleanset_id: ID of cleanset to download columns from.
+            cleanset_id: ID of cleanset to download columns from. To obtain cleanset ID from project ID use, [get_latest_cleanset_id](#method-get_latest_cleanset_id).
             include_action: Whether to include a column with any actions taken on the cleanset in the downloaded columns.
 
         Returns:
@@ -104,7 +104,7 @@ class Studio:
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:
         """
-        Applies corrections from a Cleanlab Studio cleanset to your dataset. Corrections can be made by viewing your project in the Cleanlab Studio webapp.
+        Applies corrections from a Cleanlab Studio cleanset to your dataset. Corrections can be made by viewing your project in the Cleanlab Studio webapp (see [Cleanlab Studio web quickstart](../../guide/quickstart/web#review-the-errors)).
 
         Args:
             cleanset_id: ID of cleanset to apply corrections from.

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -1,3 +1,6 @@
+"""
+Python API for Cleanlab Studio.
+"""
 from typing import Any, List, Literal, Optional
 
 import numpy as np
@@ -23,6 +26,12 @@ from cleanlab_studio.internal.types import FieldSchemaDict
 
 
 class Studio:
+    """Used to interact with Cleanlab Studio
+
+    Attributes:
+        _api_key: API key for user interacting with Cleanlab Studio
+    """
+
     _api_key: str
 
     def __init__(self, api_key: Optional[str]):

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -23,11 +23,7 @@ if _pyspark_exists:
 
 
 class Studio:
-    """Used to interact with Cleanlab Studio
-
-    Attributes:
-        _api_key: API key for user interacting with Cleanlab Studio
-    """
+    """Used to interact with Cleanlab Studio."""
 
     _api_key: str
 
@@ -59,17 +55,17 @@ class Studio:
         id_column: Optional[str] = None,
     ) -> str:
         """
-        Uploads a dataset to Cleanlab Studio
+        Uploads a dataset to Cleanlab Studio.
 
         Args:
-            dataset: Object representing the dataset to upload. Currently supported formats include a `str` path to your dataset, a pandas DataFrame, a pyspark DataFrame
-            dataset_name: Name for your dataset in Cleanlab Studio (optional if uploading from filepath)
-            schema_overrides: Optional dictionary of overrides you would like to make to the schema of your dataset. If not provided, schema will be inferred
-            modality: Optional parameter to override the modality of your dataset. If not provided, modality will be inferred
-            id_column: Optional parameter to override the ID column of your dataset. If not provided, a monotonically increasing ID column will be generated
+            dataset: Object representing the dataset to upload. Currently supported formats include a `str` path to your dataset, a pandas DataFrame, a pyspark DataFrame.
+            dataset_name: Name for your dataset in Cleanlab Studio (optional if uploading from filepath).
+            schema_overrides: Optional dictionary of overrides you would like to make to the schema of your dataset. If not provided, schema will be inferred.
+            modality: Optional parameter to override the modality of your dataset. If not provided, modality will be inferred.
+            id_column: Optional parameter to override the ID column of your dataset. If not provided, a monotonically increasing ID column will be generated.
 
         Returns:
-            ID of uploaded dataset
+            ID of uploaded dataset.
         """
         ds = init_dataset_source(dataset, dataset_name)
         return upload.upload_dataset(
@@ -87,15 +83,14 @@ class Studio:
         to_spark: bool = False,
     ) -> Any:
         """
-        Downloads Cleanlab columns for a cleanset
+        Downloads Cleanlab columns for a cleanset.
 
         Args:
-            cleanset_id: ID of cleanset to download columns from
-            include_action: Whether to include a column with any actions taken on the cleanset in the downloaded columns
+            cleanset_id: ID of cleanset to download columns from.
+            include_action: Whether to include a column with any actions taken on the cleanset in the downloaded columns.
 
         Returns:
-            A pandas or pyspark DataFrame
-            Type Any because don't want to rely on pyspark being installed
+            A pandas or pyspark DataFrame. Type is `Any` to avoid requiring pyspark installation.
         """
         rows_df = api.download_cleanlab_columns(
             self._api_key, cleanset_id, all=True, to_spark=to_spark
@@ -109,15 +104,15 @@ class Studio:
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:
         """
-        Applies corrections from a Cleanlab Studio cleanset to your dataset. Corrections can be made by viewing your project in the Cleanlab Studio webapp
+        Applies corrections from a Cleanlab Studio cleanset to your dataset. Corrections can be made by viewing your project in the Cleanlab Studio webapp.
 
         Args:
-            cleanset_id: ID of cleanset to apply corrections from
-            dataset: Dataset to apply corrections to. Supported formats include pandas DataFrame and pyspark DataFrame. Dataset should have the same number of rows as the dataset used to create the project. It should also contain a label column with the same name as the label column for the project
-            keep_excluded: Whether to retain rows with an "exclude" action. By default these rows will be removed from the dataset
+            cleanset_id: ID of cleanset to apply corrections from.
+            dataset: Dataset to apply corrections to. Supported formats include pandas DataFrame and pyspark DataFrame. Dataset should have the same number of rows as the dataset used to create the project. It should also contain a label column with the same name as the label column for the project.
+            keep_excluded: Whether to retain rows with an "exclude" action. By default these rows will be removed from the dataset.
 
         Returns:
-            A copy of the dataset with corrections applied
+            A copy of the dataset with corrections applied.
         """
         project_id = api.get_project_of_cleanset(self._api_key, cleanset_id)
         label_column = api.get_label_column_of_project(self._api_key, project_id)
@@ -201,20 +196,20 @@ class Studio:
         text_column: Optional[str] = None,
     ) -> str:
         """
-        Creates a Cleanlab Studio project
+        Creates a Cleanlab Studio project.
 
         Args:
-            dataset_id: ID of dataset to create project for
-            project_name: name for resulting project
-            modality: modality of project (i.e. text, tabular, image)
-            task_type: type of classification to perform (i.e. multi-class, multi-label)
-            model_type: type of model to train (i.e. fast, regular)
-            label_column: name of column in dataset containing labels (if not supplied, we'll make our best guess)
-            feature_columns: list of columns to use as features when training tabular modality project (if not supplied and modality is "tabular" we'll use all valid feature columns)
-            text_column: name of column containing the text to train text modality project on (if not supplied and modality is "text" we'll make our best guess)
+            dataset_id: ID of dataset to create project for.
+            project_name: name for resulting project.
+            modality: modality of project (i.e. text, tabular, image).
+            task_type: type of classification to perform (i.e. multi-class, multi-label).
+            model_type: type of model to train (i.e. fast, regular).
+            label_column: name of column in dataset containing labels (if not supplied, we'll make our best guess).
+            feature_columns: list of columns to use as features when training tabular modality project (if not supplied and modality is "tabular" we'll use all valid feature columns).
+            text_column: name of column containing the text to train text modality project on (if not supplied and modality is "text" we'll make our best guess).
 
         Returns:
-            ID of created project
+            ID of created project.
         """
         dataset_details = api.get_dataset_details(self._api_key, dataset_id)
 
@@ -262,35 +257,35 @@ class Studio:
 
     def poll_cleanset_status(self, cleanset_id: str, timeout: Optional[int] = None) -> bool:
         """
-        Polls for cleanset status. Blocks until cleanset is ready, there is a cleanset error, or `timeout` is exceeded
+        Polls for cleanset status. Blocks until cleanset is ready, there is a cleanset error, or `timeout` is exceeded.
 
         Args:
-            cleanset_id: ID of cleanset to check status of
-            timeout: Optional timeout after which to stop polling for progress. If not provided, will block until cleanset is ready
+            cleanset_id: ID of cleanset to check status of.
+            timeout: Optional timeout after which to stop polling for progress. If not provided, will block until cleanset is ready.
 
         Returns:
-            `True` if cleanset is ready, `False` otherwise
+            `True` if cleanset is ready, `False` otherwise.
         """
         return clean.poll_cleanset_status(self._api_key, cleanset_id, timeout)
 
     def get_latest_cleanset_id(self, project_id: str) -> str:
         """
-        Gets latest cleanset ID for a project
+        Gets latest cleanset ID for a project.
 
         Args:
-            project_id: ID of project
+            project_id: ID of project.
 
         Returns:
-            ID of latest associated cleanset
+            ID of latest associated cleanset.
         """
         return api.get_latest_cleanset_id(self._api_key, project_id)
 
     def delete_project(self, project_id: str) -> None:
         """
-        Deletes a project from Cleanlab Studio
+        Deletes a project from Cleanlab Studio.
 
         Args:
-            project_id: ID of project to delete
+            project_id: ID of project to delete.
         """
         api.delete_project(self._api_key, project_id)
         print(f"Successfully deleted project: {project_id}")

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -200,13 +200,13 @@ class Studio:
 
         Args:
             dataset_id: ID of dataset to create project for.
-            project_name: name for resulting project.
-            modality: modality of project (i.e. text, tabular, image).
-            task_type: type of classification to perform (i.e. multi-class, multi-label).
-            model_type: type of model to train (i.e. fast, regular).
-            label_column: name of column in dataset containing labels (if not supplied, we'll make our best guess).
-            feature_columns: list of columns to use as features when training tabular modality project (if not supplied and modality is "tabular" we'll use all valid feature columns).
-            text_column: name of column containing the text to train text modality project on (if not supplied and modality is "text" we'll make our best guess).
+            project_name: Name for resulting project.
+            modality: Modality of project (i.e. text, tabular, image).
+            task_type: Type of classification to perform (i.e. multi-class, multi-label).
+            model_type: Type of model to train (i.e. fast, regular).
+            label_column: Name of column in dataset containing labels (if not supplied, we'll make our best guess).
+            feature_columns: List of columns to use as features when training tabular modality project (if not supplied and modality is "tabular" we'll use all valid feature columns).
+            text_column: Name of column containing the text to train text modality project on (if not supplied and modality is "text" we'll make our best guess).
 
         Returns:
             ID of created project.


### PR DESCRIPTION
This PR adds docstrings for all user facing Python API functions in the format required for autogenerating the API reference on our new docs site.

To view generated API reference:
1. checkout this branch of `cleanlab-studio`
2. run `pip install --editable .`
3. clone `cleanlab-studio-docs` repo
4. run `make install` from inside `cleanlab-studio-docs`
5. run `make update-api-reference`
6. run `make docs`
7. view docs at localhost:3000