### PR TITLE
Fix: guess filetype from filename instead of dataset name

### DIFF
--- a/cleanlab_studio/internal/dataset_source/filepath_dataset_source.py
+++ b/cleanlab_studio/internal/dataset_source/filepath_dataset_source.py
@@ -7,12 +7,16 @@ from .dataset_source import DatasetSource
 
 class FilepathDatasetSource(DatasetSource):
     def __init__(
-        self, *args: Any, filepath: pathlib.Path, dataset_name: Optional[str] = None, **kwargs: Any
+        self,
+        *args: Any,
+        filepath: pathlib.Path,
+        dataset_name: Optional[str] = None,
+        **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self.dataset_name = dataset_name if dataset_name is not None else filepath.name
         self.file_size = filepath.stat().st_size
-        maybe_file_type = mimetypes.guess_type(self.dataset_name)[0]
+        maybe_file_type = mimetypes.guess_type(filepath)[0]
         if maybe_file_type is None:
             raise ValueError(
                 f"Could not identify type of file at {filepath}. Make sure file name has valid extension"


### PR DESCRIPTION
Fixes bug where we attempt to get file type from dataset name instead of filepath for datasets initialized from a filepath.