### PR TITLE
sort by cleanlab-generated ID if one exists

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -195,10 +195,12 @@ def download_cleanlab_columns(
         rdd = spark.sparkContext.parallelize([cleanset_json])
         cleanset_pyspark: pyspark.sql.DataFrame = spark.read.json(rdd)
         cleanset_pyspark = cleanset_pyspark.withColumnRenamed("id", id_col)
+        cleanset_pyspark = cleanset_pyspark.sort(id_col)
         return cleanset_pyspark
 
     cleanset_pd: pd.DataFrame = pd.read_json(cleanset_json, orient="table")
     cleanset_pd.rename(columns={"id": id_col}, inplace=True)
+    cleanset_pd.sort_values(by=id_col, inplace=True)
     return cleanset_pd
 
 

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -72,8 +72,6 @@ class Studio:
                 rows_df = rows_df.drop("action")
             else:
                 rows_df.drop("action", inplace=True, axis=1)
-        if "cleanlab_row_ID" in rows_df.columns:
-            rows_df.sort_values(by="cleanlab_row_ID", inplace=True)
         return rows_df
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -72,6 +72,8 @@ class Studio:
                 rows_df = rows_df.drop("action")
             else:
                 rows_df.drop("action", inplace=True, axis=1)
+        if "cleanlab_row_ID" in rows_df.columns:
+            rows_df.sort_values(by="cleanlab_row_ID")
         return rows_df
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -73,7 +73,7 @@ class Studio:
             else:
                 rows_df.drop("action", inplace=True, axis=1)
         if "cleanlab_row_ID" in rows_df.columns:
-            rows_df.sort_values(by="cleanlab_row_ID")
+            rows_df.sort_values(by="cleanlab_row_ID", inplace=True)
         return rows_df
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:


### PR DESCRIPTION
@sanjanag and @anishathalye ran into a problem where rows are returned in an arbitrary order, rather than being sorted by cleanlab ID  - see [https://github.com/cleanlab/cleanlab-studio-integration/issues/1113](https://github.com/cleanlab/cleanlab-studio-integration/issues/1113 ) for additional context.

This checks for our autogenerated ID column and returns it ordered by that column if one exists. 

"Design" notes: I didn't add defensive checks such as checking if integer etc. because cleanlab_row_ID is an internal column that users' shouldn't be messing with. I also didn't reindex because 1) unneccesary computation; could slow export for big datasets and 2) autogenerate ID is autoselected and many users have other ID columns :) 