### PR TITLE
add  version header to CLI

### DIFF
--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -38,6 +38,8 @@ def _construct_headers(
     if content_type:
         retval["Content-Type"] = content_type
     retval["Client-Type"] = "cli"
+    retval["User-Agent"] = f"cleanlab-studio/v{__version__}"
+    return retval
     return retval
 
 


### PR DESCRIPTION
Use the User-Agent header to add information about which version of the CLI was used to make a request. Useful for debugging. 

Closes https://github.com/cleanlab/cleanlab-studio-integration/issues/1124