### PR TITLE
Feat/inference arbitrary batches

### DIFF
--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from cleanlab_studio.internal.api import api
 
-BATCH_MAX_TEXT, BATCH_MAX_TABULAR = 100000, 100000
+BATCH_MAX_TEXT, BATCH_MAX_TABULAR = 10000, 100000
 TextBatch = Union[List[str], npt.NDArray[np.str_], pd.Series]
 TabularBatch: TypeAlias = pd.DataFrame
 Batch = Union[TextBatch, TabularBatch]

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -2,7 +2,7 @@ import abc
 import csv
 import io
 import time
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, cast
 from typing_extensions import TypeAlias
 import logging
 
@@ -62,7 +62,8 @@ class Model(abc.ABC):
             batched_probs.append(class_probabilities)
         preds_type = int if isinstance(batched_preds[0][0], int) else str
         ret_arr = np.concatenate(batched_preds)
-        ret_arr = ret_arr.astype(preds_type)
+        ret_arr = cast(ret_arr.astype(preds_type), Predictions)
+
         if return_pred_proba:
             return ret_arr, pd.concat(batched_probs)
 

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -48,7 +48,8 @@ class Model(abc.ABC):
         batchsize = BATCH_MAX_TABULAR if isinstance(batch, TabularBatch) else BATCH_MAX_TEXT
         batched_preds = []
         batched_probs = []
-        for i in range(len(batch) // batchsize + 1):
+        num_batches = len(batch) // batchsize + (1 if len(batch) % batchsize != 0 else 0)
+        for i in range(num_batches):
             start = i * batchsize
             csv_batch = self._convert_batch_to_csv(
                 batch[start : min(start + batchsize, len(batch))]
@@ -58,7 +59,9 @@ class Model(abc.ABC):
             batched_probs.append(class_probabilities)
 
         if return_pred_proba:
-            return np.concatenate(batched_preds), pd.concat(batched_probs)
+            return np.concatenate(batched_preds, dtype=batched_preds[0].dtype), pd.concat(
+                batched_probs
+            )
 
         return np.concatenate(batched_preds)
 

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from cleanlab_studio.internal.api import api
 
-BATCH_MAX_TEXT, BATCH_MAX_TABULAR = 10000, 10000
+BATCH_MAX_TEXT, BATCH_MAX_TABULAR = 100000, 100000
 TextBatch = Union[List[str], npt.NDArray[np.str_], pd.Series]
 TabularBatch: TypeAlias = pd.DataFrame
 Batch = Union[TextBatch, TabularBatch]

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -48,9 +48,10 @@ class Model(abc.ABC):
         Returns:
             predictions from batch as a numpy array, optionally also pandas dataframe of class probabilties
         """
-        batchsize = BATCH_MAX_TABULAR if isinstance(batch, TabularBatch) else BATCH_MAX_TEXT
-        batched_preds = []
-        batched_probs = []
+
+        batchsize: int = BATCH_MAX_TABULAR if isinstance(batch, TabularBatch) else BATCH_MAX_TEXT
+        batched_preds: List[Predictions] = []
+        batched_probs: List[ClassProbablities] = []
         num_batches = len(batch) // batchsize + (1 if len(batch) % batchsize != 0 else 0)
         for i in range(num_batches):
             start = i * batchsize

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -62,7 +62,7 @@ class Model(abc.ABC):
             batched_probs.append(class_probabilities)
         preds_type = int if isinstance(batched_preds[0][0], int) else str
         ret_arr = np.concatenate(batched_preds)
-        ret_arr = cast(ret_arr.astype(preds_type), Predictions)
+        ret_arr = cast(Predictions, ret_arr.astype(preds_type))
 
         if return_pred_proba:
             return ret_arr, pd.concat(batched_probs)

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -52,7 +52,7 @@ class Model(abc.ABC):
         batchsize: int = BATCH_MAX_TABULAR if isinstance(batch, pd.DataFrame) else BATCH_MAX_TEXT
         batched_preds: List[Predictions] = []
         batched_probs: List[ClassProbablities] = []
-        num_batches = len(batch) // batchsize + (1 if len(batch) % batchsize != 0 else 0)
+        num_batches = math.ceil(len(batch) / batchsize)
         for i in range(num_batches):
             start = i * batchsize
             csv_batch = self._convert_batch_to_csv(

--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -49,7 +49,7 @@ class Model(abc.ABC):
             predictions from batch as a numpy array, optionally also pandas dataframe of class probabilties
         """
 
-        batchsize: int = BATCH_MAX_TABULAR if isinstance(batch, TabularBatch) else BATCH_MAX_TEXT
+        batchsize: int = BATCH_MAX_TABULAR if isinstance(batch, pd.DataFrame) else BATCH_MAX_TEXT
         batched_preds: List[Predictions] = []
         batched_probs: List[ClassProbablities] = []
         num_batches = len(batch) // batchsize + (1 if len(batch) % batchsize != 0 else 0)


### PR DESCRIPTION
Split each batch into sub-batches so that users don't have to deal with timeout problems when using inference API. 

See this notion doc: https://www.notion.so/cleanlab/Model-Inference-Python-API-d5209e022f744298835010dbbfb26a4c 

10,000 for text and 100,000 seems like a safe number based on my own testing, but I would appreciate help testing further. 