### PR TITLE
Fix bug with using chain instead of cycle

### DIFF
--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -11,7 +11,7 @@ from cleanlab_studio.internal.api import api
 def poll_cleanset_status(api_key: str, cleanset_id: str, timeout: Optional[float] = None) -> None:
     start_time = time.time()
     res = api.get_cleanset_status(api_key, cleanset_id)
-    spinner = itertools.chain("|/-\\")
+    spinner = itertools.cycle("|/-\\")
 
     with tqdm(
         total=res["total_steps"],


### PR DESCRIPTION
`itertools.chain` is the wrong method to use, it creates a finite-length iterable, and so the code to display the spinner raises a `StopIteration` after going through the characters once.