### PR TITLE
change default upload df type to json

### DIFF
--- a/cleanlab_studio/internal/dataset_source/dataframe_dataset_source.py
+++ b/cleanlab_studio/internal/dataset_source/dataframe_dataset_source.py
@@ -25,7 +25,7 @@ class DataFrameDatasetSource(DatasetSource, Generic[DataFrame]):
         self.dataset_name = dataset_name
         self._fileobj = self._init_fileobj_from_df(df)
         self.file_size = self._get_size_in_bytes()
-        self.file_type = "text/csv"
+        self.file_type = "application/json"
 
     @abstractmethod
     def _init_fileobj_from_df(self, df: DataFrame) -> IO[bytes]:
@@ -37,4 +37,4 @@ class DataFrameDatasetSource(DatasetSource, Generic[DataFrame]):
             return dataset_file.tell()
 
     def get_filename(self) -> str:
-        return str(pathlib.Path(self.dataset_name).with_suffix(".csv"))
+        return str(pathlib.Path(self.dataset_name).with_suffix(".json"))

--- a/cleanlab_studio/internal/dataset_source/pandas_dataset_source.py
+++ b/cleanlab_studio/internal/dataset_source/pandas_dataset_source.py
@@ -8,6 +8,6 @@ from .dataframe_dataset_source import DataFrameDatasetSource
 class PandasDatasetSource(DataFrameDatasetSource[pd.DataFrame]):
     def _init_fileobj_from_df(self, df: pd.DataFrame) -> IO[bytes]:
         fileobj = io.BytesIO()
-        df.to_csv(fileobj, index=False)
+        df.to_json(fileobj, orient="records")
         fileobj.seek(0)
         return fileobj

--- a/cleanlab_studio/internal/dataset_source/pyspark_dataset_source.py
+++ b/cleanlab_studio/internal/dataset_source/pyspark_dataset_source.py
@@ -17,6 +17,6 @@ class PySparkDatasetSource(DataFrameDatasetSource[pyspark.sql.DataFrame]):
     def _init_fileobj_from_df(self, df: pyspark.sql.DataFrame) -> IO[bytes]:
         fileobj = io.BytesIO()
         pd_df: pd.DataFrame = df.toPandas()
-        pd_df.to_csv(fileobj, index=False)
+        pd_df.to_json(fileobj, orient="records")
         fileobj.seek(0)
         return fileobj

--- a/cleanlab_studio/internal/upload_helpers.py
+++ b/cleanlab_studio/internal/upload_helpers.py
@@ -68,6 +68,7 @@ async def upload_file_parts_async(
         task_results = await asyncio.gather(*tasks)
     return [
         # TODO: need to give handle error for missing etags
+        # next line currently fails typing because res.get("etag") can be None
         {"ETag": json.loads(res.get("etag")), "PartNumber": i + 1}  # type: ignore
         for i, res in enumerate(task_results)
     ]

--- a/cleanlab_studio/internal/upload_helpers.py
+++ b/cleanlab_studio/internal/upload_helpers.py
@@ -67,7 +67,8 @@ async def upload_file_parts_async(
             )
         task_results = await asyncio.gather(*tasks)
     return [
-        {"ETag": json.loads(res.get("etag")), "PartNumber": i + 1}
+        # TODO: need to give handle error for missing etags
+        {"ETag": json.loads(res.get("etag")), "PartNumber": i + 1}  # type: ignore
         for i, res in enumerate(task_results)
     ]
 


### PR DESCRIPTION
### Description

Part of a number of PRs that enable better handling of unlabeled data upload for multi-label data. Desired changes:
- csv upload: treat empty values as null 
- json upload: keep empty strings as is 
- support `metadata.json` for image zip upload
- Change default Python API upload to use JSON (this PR)
- for multi-label projects, treat null label as unlabeled, and treat empty-string labels as having no label


### How should this be tested?

Upload dataset with both empty strings and NULLs, check (in postgres is fine) if empty strings are included in IS NULL query.


### Checklist

<!-- Check the relevant items -->

- [x] PR was tested and change works as expected
