### PR TITLE
fix total progress state when checking cleanset progress

### DIFF
--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -36,7 +36,7 @@ def poll_cleanset_status(api_key: str, cleanset_id: str, timeout: Optional[float
             res = api.get_cleanset_status(api_key, cleanset_id)
 
         if res["is_ready"]:
-            pbar.update(int(res["step"]) - pbar.n)
+            pbar.update(pbar.total - pbar.n)
             pbar.set_postfix_str(res["step_description"])
             return
 


### PR DESCRIPTION
This PR fixes an issue with how cleanset progress is displayed for completed projects when polling cleanset status from the Python API. Currently, when training is complete, the progress shows up as "Cleanset Progress: Step 16/?, Ready for review!". This is because `res["step"]` is greater than total training stages when training is complete.