### PR TITLE
Fix: fail when invalid api key is passed to Studio

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -1,6 +1,7 @@
 """
 Python API for Cleanlab Studio.
 """
+from multiprocessing.sharedctypes import Value
 from typing import Any, List, Literal, Optional, Union
 import warnings
 
@@ -45,7 +46,11 @@ class Studio:
                 raise ValueError(
                     "No API key found; either specify API key or log in with 'cleanlab login' first"
                 )
-        api.validate_api_key(api_key)
+        if not api.validate_api_key(api_key):
+            raise ValueError(
+                f"Invalid API key, please check if it is properly specified: {api_key}"
+            )
+
         self._api_key = api_key
 
     def upload_dataset(

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -1,7 +1,6 @@
 """
 Python API for Cleanlab Studio.
 """
-from multiprocessing.sharedctypes import Value
 from typing import Any, List, Literal, Optional, Union
 import warnings
 


### PR DESCRIPTION
Previously, we called the `validate` endpoint but didn't check the result. This makes it such that there will be an immediate failure when a bad API key is passed, rather than waiting until another endpoint is called (and returning a bad error message)

Closes https://github.com/cleanlab/cleanlab-studio-integration/issues/1381