### PR TITLE
[TLM improvements] Update base TLM quality_preset to medium

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -345,7 +345,7 @@ class Studio:
         return np.asarray(api.download_array(self._api_key, cleanset_id, "embeddings"))
 
     def TLM(
-        self, *, quality_preset: trustworthy_language_model.QualityPreset = "low"
+        self, *, quality_preset: trustworthy_language_model.QualityPreset = "medium"
     ) -> trustworthy_language_model.TLM:
         """Gets Trustworthy Language Model (TLM) object to prompt.
 


### PR DESCRIPTION
Reason for bumping quality: The confidence scores returned by quality_preset = "medium" TLM most closely resemble those benchmarked in original paper and give significantly better vibes. This PR can be closed or approved pending final decision to bump scores or not.

