### PR TITLE
handle NA values for multilabel inference

### DIFF
--- a/cleanlab_studio/studio/inference.py
+++ b/cleanlab_studio/studio/inference.py
@@ -6,7 +6,7 @@ import abc
 import csv
 import io
 import time
-from typing import List, Tuple, Union, Any
+from typing import List, Optional, Tuple, Union, Any
 from typing_extensions import TypeAlias
 
 import numpy as np
@@ -153,11 +153,13 @@ class Model(abc.ABC):
         return sio
 
 
-def csv_string_to_list(csv_string: str) -> List[str]:
+def csv_string_to_list(csv_string: Optional[str]) -> List[str]:
     """Convert a csv string with one row that represents a list into a list
 
     Return empty list if string is empty
     """
+    if pd.isna(csv_string):
+        return []
     input_stream = io.StringIO(csv_string)
     reader = csv.reader(input_stream)
     for row in reader:


### PR DESCRIPTION
Currently get errors when running multi-label inference if a row has no suggested labels. This PR adds handling for this edge case.

<img width="1081" alt="Screenshot 2023-12-27 at 1 50 45 PM" src="https://github.com/cleanlab/cleanlab-studio/assets/122922961/948b4279-8fa1-42f0-a94f-8303db52f5a3">
