### PR TITLE
fix future warning when calling pandas read_json

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -216,7 +216,8 @@ def download_cleanlab_columns(
         cleanset_pyspark = cleanset_pyspark.sort(id_col)
         return cleanset_pyspark
 
-    cleanset_pd: pd.DataFrame = pd.read_json(cleanset_json, orient="table")
+    cleanset_json_io = io.StringIO(cleanset_json)
+    cleanset_pd: pd.DataFrame = pd.read_json(cleanset_json_io, orient="table")
     cleanset_pd.rename(columns={"id": id_col}, inplace=True)
     cleanset_pd.sort_values(by=id_col, inplace=True)
     return cleanset_pd


### PR DESCRIPTION
This PR wraps the cleanset json in StringIO when downloading cleanlab columns to avoid getting a FutureWarning from pandas.read_json(). Closes https://github.com/cleanlab/cleanlab-studio-integration/issues/1498

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206261687873254