### PR TITLE
support creating projects w no tasktype (fully unlabeled)

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -286,7 +286,7 @@ def clean_dataset(
     api_key: str,
     dataset_id: str,
     project_name: str,
-    task_type: str,
+    task_type: Optional[str],
     modality: str,
     model_type: str,
     label_column: str,

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -271,7 +271,7 @@ def get_dataset_schema(api_key: str, dataset_id: str) -> JSONDict:
     return schema
 
 
-def get_dataset_details(api_key: str, dataset_id: str, task_type: str) -> JSONDict:
+def get_dataset_details(api_key: str, dataset_id: str, task_type: Optional[str]) -> JSONDict:
     res = requests.get(
         project_base_url + f"/dataset_details/{dataset_id}",
         params=dict(tasktype=task_type),
@@ -289,7 +289,7 @@ def clean_dataset(
     task_type: Optional[str],
     modality: str,
     model_type: str,
-    label_column: str,
+    label_column: Optional[str],
     feature_columns: List[str],
     text_column: Optional[str],
 ) -> str:

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -163,7 +163,9 @@ class Studio:
         project_name: str,
         modality: Literal["text", "tabular", "image"],
         *,
-        task_type: Optional[Literal["multi-class", "multi-label", "regression"]] = "multi-class",
+        task_type: Optional[
+            Literal["multi-class", "multi-label", "regression", "unsupervised"]
+        ] = "multi-class",
         model_type: Literal["fast", "regular"] = "regular",
         label_column: Optional[str] = None,
         feature_columns: Optional[List[str]] = None,
@@ -192,7 +194,7 @@ class Studio:
                 raise ValueError(
                     f"Invalid label column '{label_column}' for task type '{task_type}'"
                 )
-        elif task_type is not None:
+        elif task_type is not None and task_type != "unsupervised":
             label_column = str(dataset_details["label_column_guess"])
             print(f"Label column not supplied. Using best guess {label_column}")
 

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -193,7 +193,7 @@ class Studio:
                 raise ValueError(
                     f"Invalid label column '{label_column}' for task type '{task_type}'"
                 )
-        else:
+        elif task_type is not None:
             label_column = str(dataset_details["label_column_guess"])
             print(f"Label column not supplied. Using best guess {label_column}")
 

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -15,7 +15,6 @@ from cleanlab_studio.internal import clean_helpers, upload_helpers
 from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.util import (
     init_dataset_source,
-    check_none,
     apply_corrections_snowpark_df,
     apply_corrections_spark_df,
     apply_corrections_pd_df,
@@ -164,7 +163,7 @@ class Studio:
         project_name: str,
         modality: Literal["text", "tabular", "image"],
         *,
-        task_type: Literal["multi-class", "multi-label", "regression"] = "multi-class",
+        task_type: Optional[Literal["multi-class", "multi-label", "regression"]] = "multi-class",
         model_type: Literal["fast", "regular"] = "regular",
         label_column: Optional[str] = None,
         feature_columns: Optional[List[str]] = None,

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -203,7 +203,8 @@ class Studio:
         if feature_columns is None:
             if modality == "tabular":
                 feature_columns = dataset_details["distinct_columns"]
-                feature_columns.remove(label_column)
+                if label_column is not None:
+                    feature_columns.remove(label_column)
                 print(f"Feature columns not supplied. Using all valid feature columns")
 
         if text_column is not None:


### PR DESCRIPTION
Adds support for creating projects with no label column through the Python API. These projects will be created using tasktype `None` (or `"unsupervised"`). See associated [training](https://github.com/cleanlab/cleanlab-studio-training/pull/492) and [backend](https://github.com/cleanlab/cleanlab-studio-backend/pull/1061) PRs for more info.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206247072076449