### PR TITLE
Check IDs for if they are valid UUIDs

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -26,6 +26,7 @@ except ImportError:
 
 from cleanlab_studio.internal.types import JSONDict
 from cleanlab_studio.version import __version__
+from ..util import check_uuid_well_formed
 
 
 base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api")
@@ -98,6 +99,7 @@ def initialize_upload(
 
 
 def complete_file_upload(api_key: str, upload_id: str, upload_parts: List[JSONDict]) -> None:
+    check_uuid_well_formed(upload_id, "upload ID")
     request_json = dict(upload_id=upload_id, upload_parts=upload_parts)
     res = requests.post(
         f"{upload_base_url}/complete",
@@ -108,6 +110,7 @@ def complete_file_upload(api_key: str, upload_id: str, upload_parts: List[JSONDi
 
 
 def get_proposed_schema(api_key: str, upload_id: str) -> JSONDict:
+    check_uuid_well_formed(upload_id, "upload ID")
     res = requests.get(
         f"{upload_base_url}/proposed_schema",
         params=dict(upload_id=upload_id),
@@ -123,6 +126,7 @@ def confirm_schema(
     schema: Optional[JSONDict],
     upload_id: str,
 ) -> None:
+    check_uuid_well_formed(upload_id, "upload ID")
     request_json = dict(schema=schema, upload_id=upload_id)
     res = requests.post(
         f"{upload_base_url}/confirm_schema",
@@ -133,6 +137,7 @@ def confirm_schema(
 
 
 def get_ingestion_status(api_key: str, upload_id: str) -> JSONDict:
+    check_uuid_well_formed(upload_id, "upload ID")
     res = requests.get(
         f"{upload_base_url}/ingestion_status",
         params=dict(upload_id=upload_id),
@@ -144,6 +149,7 @@ def get_ingestion_status(api_key: str, upload_id: str) -> JSONDict:
 
 
 def get_dataset_id(api_key: str, upload_id: str) -> JSONDict:
+    check_uuid_well_formed(upload_id, "upload ID")
     res = requests.get(
         f"{upload_base_url}/dataset_id",
         params=dict(upload_id=upload_id),
@@ -155,6 +161,7 @@ def get_dataset_id(api_key: str, upload_id: str) -> JSONDict:
 
 
 def get_project_of_cleanset(api_key: str, cleanset_id: str) -> str:
+    check_uuid_well_formed(cleanset_id, "cleanset ID")
     res = requests.get(
         cli_base_url + f"/cleansets/{cleanset_id}/project",
         headers=_construct_headers(api_key),
@@ -165,6 +172,7 @@ def get_project_of_cleanset(api_key: str, cleanset_id: str) -> str:
 
 
 def get_label_column_of_project(api_key: str, project_id: str) -> str:
+    check_uuid_well_formed(project_id, "project ID")
     res = requests.get(
         cli_base_url + f"/projects/{project_id}/label_column",
         headers=_construct_headers(api_key),
@@ -190,6 +198,7 @@ def download_cleanlab_columns(
     :param include_project_details: whether to download columns related to project status such as resolved rows, actions taken, etc.
     :return: return a dataframe, either pandas or spark. Type is Any because don't want to require spark installed
     """
+    check_uuid_well_formed(cleanset_id, "cleanset ID")
     res = requests.get(
         cli_base_url + f"/cleansets/{cleanset_id}/columns",
         params=dict(
@@ -226,6 +235,7 @@ def download_cleanlab_columns(
 def download_array(
     api_key: str, cleanset_id: str, name: str
 ) -> Union[npt.NDArray[np.float_], pd.DataFrame]:
+    check_uuid_well_formed(cleanset_id, "cleanset ID")
     res = requests.get(
         cli_base_url + f"/cleansets/{cleanset_id}/{name}",
         headers=_construct_headers(api_key),
@@ -242,6 +252,7 @@ def download_array(
 
 
 def get_id_column(api_key: str, cleanset_id: str) -> str:
+    check_uuid_well_formed(cleanset_id, "cleanset ID")
     res = requests.get(
         cli_base_url + f"/cleansets/{cleanset_id}/id_column",
         headers=_construct_headers(api_key),
@@ -252,6 +263,7 @@ def get_id_column(api_key: str, cleanset_id: str) -> str:
 
 
 def get_dataset_of_project(api_key: str, project_id: str) -> str:
+    check_uuid_well_formed(project_id, "project ID")
     res = requests.get(
         cli_base_url + f"/projects/{project_id}/dataset",
         headers=_construct_headers(api_key),
@@ -262,6 +274,7 @@ def get_dataset_of_project(api_key: str, project_id: str) -> str:
 
 
 def get_dataset_schema(api_key: str, dataset_id: str) -> JSONDict:
+    check_uuid_well_formed(dataset_id, "dataset ID")
     res = requests.get(
         cli_base_url + f"/datasets/{dataset_id}/schema",
         headers=_construct_headers(api_key),
@@ -272,6 +285,7 @@ def get_dataset_schema(api_key: str, dataset_id: str) -> JSONDict:
 
 
 def get_dataset_details(api_key: str, dataset_id: str, task_type: str) -> JSONDict:
+    check_uuid_well_formed(dataset_id, "dataset ID")
     res = requests.get(
         project_base_url + f"/dataset_details/{dataset_id}",
         params=dict(tasktype=task_type),
@@ -293,6 +307,7 @@ def clean_dataset(
     feature_columns: List[str],
     text_column: Optional[str],
 ) -> str:
+    check_uuid_well_formed(dataset_id, "dataset ID")
     request_json = dict(
         name=project_name,
         dataset_id=dataset_id,
@@ -314,6 +329,7 @@ def clean_dataset(
 
 
 def get_latest_cleanset_id(api_key: str, project_id: str) -> str:
+    check_uuid_well_formed(project_id, "project ID")
     res = requests.get(
         cleanset_base_url + f"/project/{project_id}/latest_cleanset_id",
         headers=_construct_headers(api_key),
@@ -324,6 +340,7 @@ def get_latest_cleanset_id(api_key: str, project_id: str) -> str:
 
 
 def get_cleanset_status(api_key: str, cleanset_id: str) -> JSONDict:
+    check_uuid_well_formed(cleanset_id, "cleanset ID")
     res = requests.get(
         cleanset_base_url + f"/{cleanset_id}/status",
         headers=_construct_headers(api_key),
@@ -334,6 +351,7 @@ def get_cleanset_status(api_key: str, cleanset_id: str) -> JSONDict:
 
 
 def delete_project(api_key: str, project_id: str) -> None:
+    check_uuid_well_formed(project_id, "project ID")
     res = requests.delete(project_base_url + f"/{project_id}", headers=_construct_headers(api_key))
     handle_api_error(res)
 
@@ -355,6 +373,7 @@ def poll_progress(
 
 def upload_predict_batch(api_key: str, model_id: str, batch: io.StringIO) -> str:
     """Uploads prediction batch and returns query ID."""
+    check_uuid_well_formed(model_id, "model ID")
     url = f"{model_base_url}/{model_id}/upload"
     res = requests.post(
         url,
@@ -372,6 +391,8 @@ def upload_predict_batch(api_key: str, model_id: str, batch: io.StringIO) -> str
 
 def start_prediction(api_key: str, model_id: str, query_id: str) -> None:
     """Starts prediction for query."""
+    check_uuid_well_formed(model_id, "model ID")
+    check_uuid_well_formed(query_id, "query ID")
     res = requests.post(
         f"{model_base_url}/{model_id}/predict/{query_id}",
         headers=_construct_headers(api_key),
@@ -382,6 +403,7 @@ def start_prediction(api_key: str, model_id: str, query_id: str) -> None:
 
 def get_prediction_status(api_key: str, query_id: str) -> Dict[str, str]:
     """Gets status of model prediction query. Returns status, and optionally the result url or error message."""
+    check_uuid_well_formed(query_id, "query ID")
     res = requests.get(
         f"{model_base_url}/predict/{query_id}",
         headers=_construct_headers(api_key),
@@ -393,6 +415,7 @@ def get_prediction_status(api_key: str, query_id: str) -> Dict[str, str]:
 
 def get_deployed_model_info(api_key: str, model_id: str) -> Dict[str, str]:
     """Get info about deployed model, including model id, name, cleanset id, dataset id, projectid, updated_at, status, and tasktype"""
+    check_uuid_well_formed(model_id, "model ID")
     res = requests.get(
         f"{model_base_url}/{model_id}",
         headers=_construct_headers(api_key),

--- a/cleanlab_studio/internal/util.py
+++ b/cleanlab_studio/internal/util.py
@@ -208,7 +208,7 @@ def quote_list(l: List[str]) -> List[str]:
     return [quote(i) for i in l]
 
 
-def check_uuid_well_formed(uuid_string: str, id_name: str):
+def check_uuid_well_formed(uuid_string: str, id_name: str) -> None:
     try:
         uuid.UUID(uuid_string)
     except ValueError:

--- a/cleanlab_studio/internal/util.py
+++ b/cleanlab_studio/internal/util.py
@@ -1,6 +1,8 @@
 import pathlib
 from typing import Any, Optional, TypeVar, Union, List
 import math
+import uuid
+
 
 import numpy as np
 import pandas as pd
@@ -204,3 +206,12 @@ def quote(s: str) -> str:
 
 def quote_list(l: List[str]) -> List[str]:
     return [quote(i) for i in l]
+
+
+def check_uuid_well_formed(uuid_string: str, id_name: str):
+    try:
+        uuid.UUID(uuid_string)
+    except ValueError:
+        raise ValueError(
+            f"{uuid_string} is not a well-formed {id_name}, please double check and try again."
+        )


### PR DESCRIPTION
Improve the error message for invalid UUIDs when calling APIs with e.g. cleanset id, dataset id, ...

This also handles these errors and doesn't trigger an error in the app.