### PR TITLE
Feature: upload v1

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     pyspark_exists = False
 
-from cleanlab_studio.internal.types import JSONDict
+from cleanlab_studio.internal.types import JSONDict, SchemaOverride
 from cleanlab_studio.version import __version__
 from ..util import check_uuid_well_formed
 
@@ -125,6 +125,21 @@ def confirm_upload(api_key: str, upload_id: str, dataset_name: str) -> None:
     request_json = dict(upload_id=upload_id)
     res = requests.post(
         f"{upload_base_url}/confirm",
+        json=request_json,
+        headers=_construct_headers(api_key),
+    )
+    handle_api_error(res)
+
+
+def update_schema(
+    api_key: str,
+    dataset_id: str,
+    schema_overrides: List[SchemaOverride],
+) -> None:
+    check_uuid_well_formed(dataset_id, "dataset ID")
+    request_json = dict(dataset_id=dataset_id, schema_updates=schema_overrides)
+    res = requests.patch(
+        f"{upload_base_url}/schema",
         json=request_json,
         headers=_construct_headers(api_key),
     )

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -2,7 +2,11 @@ from typing import Any, Dict, Optional, TypedDict
 
 
 JSONDict = Dict[str, Any]
-FieldSchemaDict = Dict[str, Dict[str, Any]]
+
+
+class SchemaOverride(TypedDict):
+    name: str
+    column_type: str
 
 
 class CleanlabSettingsDict(TypedDict):

--- a/cleanlab_studio/internal/upload_helpers.py
+++ b/cleanlab_studio/internal/upload_helpers.py
@@ -11,14 +11,14 @@ from requests.adapters import HTTPAdapter, Retry
 
 from .api import api
 from .dataset_source import DatasetSource
-from .types import FieldSchemaDict, JSONDict
+from .types import JSONDict, SchemaOverride
 
 
 def upload_dataset(
     api_key: str,
     dataset_source: DatasetSource,
     *,
-    schema_overrides: Optional[FieldSchemaDict] = None,
+    schema_overrides: Optional[List[SchemaOverride]] = None,
 ) -> str:
     # perform file upload
     upload_id = upload_dataset_file(api_key, dataset_source)
@@ -31,8 +31,12 @@ def upload_dataset(
 
     # if schema overrides, update schema and wait for reingestion
     if schema_overrides:
-        # TODO
-        ...
+        api.update_schema(
+            api_key,
+            dataset_id,
+            schema_overrides,
+        )
+        api.poll_ingestion_progress(api_key, upload_id, "Updating Schema...")
 
     # return dataset id
     return dataset_id

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -20,7 +20,7 @@ from cleanlab_studio.internal.util import (
     apply_corrections_pd_df,
 )
 from cleanlab_studio.internal.settings import CleanlabSettings
-from cleanlab_studio.internal.types import FieldSchemaDict
+from cleanlab_studio.internal.types import SchemaOverride
 
 _snowflake_exists = api.snowflake_exists
 if _snowflake_exists:
@@ -62,7 +62,7 @@ class Studio:
         dataset: Any,
         dataset_name: Optional[str] = None,
         *,
-        schema_overrides: Optional[FieldSchemaDict] = None,
+        schema_overrides: Optional[List[SchemaOverride]] = None,
     ) -> str:
         """
         Uploads a dataset to Cleanlab Studio.

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -63,8 +63,6 @@ class Studio:
         dataset_name: Optional[str] = None,
         *,
         schema_overrides: Optional[FieldSchemaDict] = None,
-        modality: Optional[str] = None,
-        id_column: Optional[str] = None,
     ) -> str:
         """
         Uploads a dataset to Cleanlab Studio.
@@ -84,8 +82,6 @@ class Studio:
             self._api_key,
             ds,
             schema_overrides=schema_overrides,
-            modality=modality,
-            id_column=id_column,
         )
 
     def download_cleanlab_columns(


### PR DESCRIPTION
Update upload flow to use V1 endpoints and flow

Testing:
- Upload a variety of datasets (both files and dataframes)
- Try setting schema overrides (and make sure they take effect)

> NOTE! we don't want to merge this branch until upload v1 is rolled out to all users