### PR TITLE
convert to json rather than csv for snowflake upload

### DIFF
--- a/cleanlab_studio/internal/dataset_source/snowpark_dataset_source.py
+++ b/cleanlab_studio/internal/dataset_source/snowpark_dataset_source.py
@@ -19,6 +19,6 @@ class SnowparkDatasetSource(DataFrameDatasetSource[snowpark.DataFrame]):
     def _init_fileobj_from_df(self, df: snowpark.DataFrame) -> IO[bytes]:
         fileobj = io.BytesIO()
         pd_df: pd.DataFrame = df.to_pandas()
-        pd_df.to_csv(fileobj, index=False)
+        pd_df.to_json(fileobj, index=False, orient="records")
         fileobj.seek(0)
         return fileobj


### PR DESCRIPTION
We switched to converting dataframes to json when uploading through the Python API a few months ago. When implementing the snowflake dataframe upload, we likely were testing based on an older version of the Python API from before that change. This PR updates the snowflake dataframe source to convert to json.