### PR TITLE
print link to cleanset when ready

### DIFF
--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -8,7 +8,12 @@ from cleanlab_studio.errors import CleansetError
 from cleanlab_studio.internal.api import api
 
 
-def poll_cleanset_status(api_key: str, cleanset_id: str, timeout: Optional[float] = None) -> None:
+def poll_cleanset_status(
+    api_key: str,
+    cleanset_id: str,
+    timeout: Optional[float] = None,
+    show_cleanset_link: bool = False,
+) -> None:
     start_time = time.time()
     res = api.get_cleanset_status(api_key, cleanset_id)
     spinner = itertools.cycle("|/-\\")
@@ -37,7 +42,12 @@ def poll_cleanset_status(api_key: str, cleanset_id: str, timeout: Optional[float
 
         if res["is_ready"]:
             pbar.update(pbar.total - pbar.n)
-            pbar.set_postfix_str(res["step_description"])
+            ready_description = res["step_description"]
+            if show_cleanset_link:
+                ready_description += (
+                    f" View your cleanset at: https://app.cleanlab.ai/cleansets/{cleanset_id}"
+                )
+            pbar.set_postfix_str(ready_description)
             return
 
         if res["has_error"]:

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -1,6 +1,7 @@
 """
 Python API for Cleanlab Studio.
 """
+
 from typing import Any, List, Literal, Optional, Union
 from types import FunctionType
 import warnings
@@ -251,6 +252,7 @@ class Studio:
             CleansetError: if cleanset errored while running
         """
         clean_helpers.poll_cleanset_status(self._api_key, cleanset_id, timeout)
+        print(f"View your cleanset at: https://app.cleanlab.ai/cleansets/{cleanset_id}")
 
     def get_latest_cleanset_id(self, project_id: str) -> str:
         """

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -240,19 +240,21 @@ class Studio:
             text_column=text_column,
         )
 
-    def wait_until_cleanset_ready(self, cleanset_id: str, timeout: Optional[float] = None) -> None:
+    def wait_until_cleanset_ready(
+        self, cleanset_id: str, timeout: Optional[float] = None, show_cleanset_link: bool = False
+    ) -> None:
         """Blocks until a cleanset is ready or the timeout is reached.
 
         Args:
             cleanset_id (str): ID of cleanset to check status for.
             timeout (Optional[float], optional): timeout for polling, in seconds. Defaults to None.
+            show_cleanset_link (bool, optional): whether to print a link to view the cleanset in the Cleanlab Studio web UI when the cleanset is ready. Defaults to False.
 
         Raises:
             TimeoutError: if cleanset is not ready by end of timeout
             CleansetError: if cleanset errored while running
         """
-        clean_helpers.poll_cleanset_status(self._api_key, cleanset_id, timeout)
-        print(f"View your cleanset at: https://app.cleanlab.ai/cleansets/{cleanset_id}")
+        clean_helpers.poll_cleanset_status(self._api_key, cleanset_id, timeout, show_cleanset_link)
 
     def get_latest_cleanset_id(self, project_id: str) -> str:
         """


### PR DESCRIPTION
This PR updates the `wait_until_cleanset_ready()` method to print a link to the cleanset page when ready to make it easier for a user to navigate to their cleanset