### PR TITLE
[TLM Improvement] Add tqdm progress bar to batch tlm methods

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -374,18 +374,29 @@ class Studio:
         self,
         *,
         quality_preset: trustworthy_language_model.QualityPreset = "medium",
+        model: trustworthy_language_model.TLMModel = "gpt-3.5-turbo-16k",
+        verbosity: bool = trustworthy_language_model.DEFAULT_VERBOSITY,
         **kwargs: Any,
     ) -> trustworthy_language_model.TLM:
         """Gets Trustworthy Language Model (TLM) object to prompt.
 
-        Args:
-            quality_preset: quality preset to use for prompts
-            kwargs (Any): additional kwargs to pass to TLM class
+        Parameters
+        ----------
+            quality_preset: QualityPreset, default = "low"
+                Quality preset to use for TLM queries
+            model: TLMModel, default = "gpt-3.5-turbo-16k"
+                ID of the model to use. Other options: "gpt-4"
+            verbosity: bool, default = True
+                Verbosity level for TLM queries. Default is True which will print progress bars for TLM queries. For silent TLM progress, set to False.
+            kwargs (Any):
+                Additional kwargs to pass to TLM class
 
         Returns:
             TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
         """
-        return trustworthy_language_model.TLM(self._api_key, quality_preset, **kwargs)
+        return trustworthy_language_model.TLM(
+            self._api_key, quality_preset, model, verbosity**kwargs
+        )
 
     def poll_cleanset_status(self, cleanset_id: str, timeout: Optional[int] = None) -> bool:
         """

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -395,7 +395,7 @@ class Studio:
             TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
         """
         return trustworthy_language_model.TLM(
-            self._api_key, quality_preset, model, verbosity**kwargs
+            self._api_key, quality_preset, model, verbosity, **kwargs
         )
 
     def poll_cleanset_status(self, cleanset_id: str, timeout: Optional[int] = None) -> bool:

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import asyncio
 import sys
 from typing import Coroutine, List, Literal, Optional, Union, cast
+from tqdm.asyncio import tqdm_asyncio
 
 import aiohttp
 from typing_extensions import NotRequired, TypedDict  # for Python <3.11 with (Not)Required
 
 from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.types import JSONDict
+
 
 valid_quality_presets = ["best", "high", "medium", "low", "base"]
 QualityPreset = Literal["best", "high", "medium", "low", "base"]
@@ -171,8 +173,7 @@ class TLM:
         timeout: Optional[float],
     ) -> Union[List[TLMResponse], List[float]]:
         tlm_query_tasks = [asyncio.create_task(tlm_coro) for tlm_coro in tlm_coroutines]
-
-        return await asyncio.wait_for(asyncio.gather(*tlm_query_tasks), timeout=timeout)  # type: ignore[arg-type]
+        return await asyncio.wait_for(tqdm_asyncio.gather(*tlm_query_tasks, total=len(tlm_query_tasks), desc="Querying TLM...", bar_format="{desc}: {percentage:3.0f}%|{bar}|"), timeout=timeout)  # type: ignore[arg-type]
 
     def prompt(self, prompt: str, options: Optional[TLMOptions] = None) -> TLMResponse:
         """

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -14,7 +14,6 @@ from typing_extensions import NotRequired, TypedDict  # for Python <3.11 with (N
 from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.types import JSONDict
 
-
 valid_quality_presets = ["best", "high", "medium", "low", "base"]
 QualityPreset = Literal["best", "high", "medium", "low", "base"]
 
@@ -173,7 +172,15 @@ class TLM:
         timeout: Optional[float],
     ) -> Union[List[TLMResponse], List[float]]:
         tlm_query_tasks = [asyncio.create_task(tlm_coro) for tlm_coro in tlm_coroutines]
-        return await asyncio.wait_for(tqdm_asyncio.gather(*tlm_query_tasks, total=len(tlm_query_tasks), desc="Querying TLM...", bar_format="{desc}: {percentage:3.0f}%|{bar}|"), timeout=timeout)  # type: ignore[arg-type]
+        return await asyncio.wait_for(
+            tqdm_asyncio.gather(
+                *tlm_query_tasks,
+                total=len(tlm_query_tasks),
+                desc="Querying TLM...",
+                bar_format="{desc}: {percentage:3.0f}%|{bar}|",
+            ),
+            timeout=timeout,
+        )
 
     def prompt(self, prompt: str, options: Optional[TLMOptions] = None) -> TLMResponse:
         """


### PR DESCRIPTION
This pr does 3 things:
- adds a progress bar to track progress for `batch_prompt` and `batch_get_confidence_score`. Progress bar just shows % complete out of total prompts and updates per prompt complete.
- adds two tlm parameters decided at initialization
  - verbosity: prints tqdm progress if true, no print otherwise
  - model: model type