### PR TITLE
Patch: TLM batch APIs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
+        with:
+          version: "22.3.0"

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -477,11 +477,8 @@ def tlm_retry(func: Callable[..., Any]) -> Callable[..., Any]:
             try:
                 return await func(*args, **kwargs)
             except RateLimitError as e:
-                sleep_time = e.retry_after
                 # note: we don't increment num_try here, because we don't want rate limit retries to count against the total number of retries
-                error_message = (
-                    "Try setting a smaller max_concurrent_requests or using a shorter prompt."
-                )
+                sleep_time = e.retry_after
             except Exception as e:
                 sleep_time = 2**num_try
                 num_try += 1

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -71,7 +71,6 @@ def handle_api_error_from_json(res_json: JSONDict) -> None:
 def handle_rate_limit_error_from_resp(resp: aiohttp.ClientResponse) -> None:
     """Catches 429 (rate limit) errors."""
     if resp.status == 429:
-        print(f"Rate limit exceeded on {resp.url}", int(resp.headers.get("Retry-After", 0)))
         raise RateLimitError(
             f"Rate limit exceeded on {resp.url}", int(resp.headers.get("Retry-After", 0))
         )
@@ -468,22 +467,24 @@ def tlm_retry(func: Callable[..., Any]) -> Callable[..., Any]:
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         # total number of tries = number of retries + original try
         retries = kwargs.pop("retries", 0)
-        num_tries = retries + 1
 
         sleep_time = 0
         error_message = ""
 
-        for num_try in range(num_tries):
+        num_try = 0
+        while num_try <= retries:
             await asyncio.sleep(sleep_time)
             try:
                 return await func(*args, **kwargs)
             except RateLimitError as e:
                 sleep_time = e.retry_after
+                # note: we don't increment num_try here, because we don't want rate limit retries to count against the total number of retries
                 error_message = (
                     "Try setting a smaller max_concurrent_requests or using a shorter prompt."
                 )
             except Exception as e:
                 sleep_time = 2**num_try
+                num_try += 1
                 error_message = str(e)
         else:
             raise APIError(f"TLM failed after {retries + 1} attempts. {error_message}", -1)

--- a/cleanlab_studio/internal/api/api_helper.py
+++ b/cleanlab_studio/internal/api/api_helper.py
@@ -8,7 +8,3 @@ def check_uuid_well_formed(uuid_string: str, id_name: str) -> None:
         raise ValueError(
             f"{uuid_string} is not a well-formed {id_name}, please double check and try again."
         )
-
-
-def is_collection(obj: object) -> bool:
-    return hasattr(obj, "__iter__") and hasattr(obj, "__len__") and hasattr(obj, "__setitem__")

--- a/cleanlab_studio/internal/api/api_helper.py
+++ b/cleanlab_studio/internal/api/api_helper.py
@@ -11,4 +11,4 @@ def check_uuid_well_formed(uuid_string: str, id_name: str) -> None:
 
 
 def is_collection(obj: object) -> bool:
-    return hasattr(obj, "__iter__") and hasattr(obj, "__len__")
+    return hasattr(obj, "__iter__") and hasattr(obj, "__len__") and hasattr(obj, "__setitem__")

--- a/cleanlab_studio/internal/api/api_helper.py
+++ b/cleanlab_studio/internal/api/api_helper.py
@@ -8,3 +8,7 @@ def check_uuid_well_formed(uuid_string: str, id_name: str) -> None:
         raise ValueError(
             f"{uuid_string} is not a well-formed {id_name}, please double check and try again."
         )
+
+
+def is_collection(obj: object) -> bool:
+    return hasattr(obj, "__iter__") and hasattr(obj, "__len__")

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -100,7 +100,7 @@ class TLM:
             List[TLMResponse]: TLM responses for each prompt (in supplied order)
         """
         if isinstance(options, list):
-            options_collection = cast(List[Union[TLMOptions, None]], options)
+            options_collection = options
         else:
             options = cast(Union[None, TLMOptions], options)
             options_collection = [options for _ in prompts]
@@ -144,7 +144,7 @@ class TLM:
             List[float]: TLM confidence score for each prompt (in supplied order)
         """
         if isinstance(options, list):
-            options_collection = cast(List[Union[TLMOptions, None]], options)
+            options_collection = options
         else:
             options = cast(Union[None, TLMOptions], options)
             options_collection = [options for _ in prompts]

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import Coroutine, Collection, List, Literal, Optional, Union, cast
+from typing import Coroutine, List, Literal, Optional, Union, cast
 
 import aiohttp
 from typing_extensions import NotRequired, TypedDict  # for Python <3.11 with (Not)Required
 
 from cleanlab_studio.internal.api import api
-from cleanlab_studio.internal.api.api_helper import is_collection
 from cleanlab_studio.internal.types import JSONDict
 
 valid_quality_presets = ["best", "high", "medium", "low", "base"]
@@ -84,24 +83,24 @@ class TLM:
 
     def _batch_prompt(
         self,
-        prompts: Collection[str],
-        options: Union[None, TLMOptions, Collection[Union[TLMOptions, None]]] = None,
+        prompts: List[str],
+        options: Union[None, TLMOptions, List[Union[TLMOptions, None]]] = None,
         timeout: Optional[float] = None,
         retries: int = 1,
     ) -> List[TLMResponse]:
         """Run batch of TLM prompts.
 
         Args:
-            prompts (Collection[str]): list or other iterable of prompts to run
-            options (None | TLMOptions | List[TLMOptions  |  None], optional): collection of options (or instance of options) to pass to prompt method. Defaults to None.
+            prompts (List[str]): list of prompts to run
+            options (None | TLMOptions | List[TLMOptions  |  None], optional): list of options (or instance of options) to pass to prompt method. Defaults to None.
             timeout (Optional[float], optional): timeout (in seconds) to run all prompts. Defaults to None.
             retries (int): number of retries to attempt for each individual prompt in case of error. Defaults to 1.
 
         Returns:
             List[TLMResponse]: TLM responses for each prompt (in supplied order)
         """
-        if is_collection(options):
-            options_collection = cast(Collection[Union[TLMOptions, None]], options)
+        if isinstance(options, list):
+            options_collection = cast(List[Union[TLMOptions, None]], options)
         else:
             options = cast(Union[None, TLMOptions], options)
             options_collection = [options for _ in prompts]
@@ -126,17 +125,17 @@ class TLM:
 
     def _batch_get_confidence_score(
         self,
-        prompts: Collection[str],
-        responses: Collection[str],
-        options: Union[None, TLMOptions, Collection[Union[TLMOptions, None]]] = None,
+        prompts: List[str],
+        responses: List[str],
+        options: Union[None, TLMOptions, List[Union[TLMOptions, None]]] = None,
         timeout: Optional[float] = None,
         retries: int = 1,
     ) -> List[float]:
         """Run batch of TLM get confidence score.
 
         Args:
-            prompts (Collection[str]): list or other iterable of prompts to run get confidence score for
-            responses (Collection[str]): list or other iterable of responses to run get confidence score for
+            prompts (List[str]): list of prompts to run get confidence score for
+            responses (List[str]): list of responses to run get confidence score for
             options (None | TLMOptions | List[TLMOptions  |  None], optional): list of options (or instance of options) to pass to get confidence score method. Defaults to None.
             timeout (Optional[float], optional): timeout (in seconds) to run all prompts. Defaults to None.
             retries (int): number of retries to attempt for each individual prompt in case of error. Defaults to 1.
@@ -144,8 +143,8 @@ class TLM:
         Returns:
             List[float]: TLM confidence score for each prompt (in supplied order)
         """
-        if is_collection(options):
-            options_collection = cast(Collection[Union[TLMOptions, None]], options)
+        if isinstance(options, list):
+            options_collection = cast(List[Union[TLMOptions, None]], options)
         else:
             options = cast(Union[None, TLMOptions], options)
             options_collection = [options for _ in prompts]
@@ -183,8 +182,8 @@ class TLM:
 
     def prompt(
         self,
-        prompt: Union[str, Collection[str]],
-        options: Union[None, TLMOptions, Collection[Union[TLMOptions, None]]] = None,
+        prompt: Union[str, List[str]],
+        options: Union[None, TLMOptions, List[Union[TLMOptions, None]]] = None,
         timeout: Optional[float] = None,
         retries: int = 1,
     ) -> Union[TLMResponse, List[TLMResponse]]:
@@ -192,8 +191,8 @@ class TLM:
         Get response and confidence from TLM.
 
         Args:
-            prompt (str | Collection[str]): prompt (or list/iterable of multiple prompts) for the TLM
-            options (None | TLMOptions | Collection[TLMOptions |  None], optional): collection of options (or instance of options) to pass to prompt method. Defaults to None.
+            prompt (str | List[str]): prompt (or list of multiple prompts) for the TLM
+            options (None | TLMOptions | List[TLMOptions |  None], optional): list of options (or instance of options) to pass to prompt method. Defaults to None.
             timeout (Optional[float], optional): timeout (in seconds) to run all prompts. Defaults to None.
                 If the timeout is hit, this method will throw a `TimeoutError`.
                 Larger values give TLM a higher chance to return outputs for all of your prompts.
@@ -206,7 +205,7 @@ class TLM:
             TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and confidence score.
                     If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.
         """
-        if is_collection(prompt):
+        if isinstance(prompt, list):
             return self._batch_prompt(
                 prompt,
                 options,
@@ -264,17 +263,17 @@ class TLM:
 
     def get_confidence_score(
         self,
-        prompt: Union[str, Collection[str]],
-        response: Union[str, Collection[str]],
-        options: Union[None, TLMOptions, Collection[Union[TLMOptions, None]]] = None,
+        prompt: Union[str, List[str]],
+        response: Union[str, List[str]],
+        options: Union[None, TLMOptions, List[Union[TLMOptions, None]]] = None,
         timeout: Optional[float] = None,
         retries: int = 1,
     ) -> Union[float, List[float]]:
         """Gets confidence score for prompt-response pair(s).
 
         Args:
-            prompt (str | Collection[str]): prompt (or list/iterable of multiple prompts) for the TLM
-            response (str | Collection[str]): response (or list/iterable of multiple responses) for the TLM to evaluate
+            prompt (str | List[str]): prompt (or list/iterable of multiple prompts) for the TLM
+            response (str | List[str]): response (or list/iterable of multiple responses) for the TLM to evaluate
             options (None | TLMOptions | List[TLMOptions  |  None], optional): list of options (or instance of options) to pass to get confidence score method. Defaults to None.
             timeout (Optional[float], optional): maximum allowed time (in seconds) to run all prompts and evaluate all responses. Defaults to None.
                 If the timeout is hit, this method will throw a `TimeoutError`.
@@ -288,8 +287,8 @@ class TLM:
             float (or list of floats if multiple prompt-responses were provided) corresponding to the TLM's confidence score.
                     The score quantifies how confident TLM is that the given response is good for the given prompt.
         """
-        if is_collection(prompt):
-            if not is_collection(response):
+        if isinstance(prompt, list):
+            if not isinstance(response, list):
                 raise ValueError(
                     "responses must be a list or iterable of strings when prompt is a list or iterable."
                 )

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -215,7 +215,10 @@ class TLM:
 
         elif isinstance(prompt, str):
             if not (options is None or isinstance(options, dict)):
-                raise ValueError("options must be a single TLMOptions object for single prompt.")
+                raise ValueError(
+                    "options must be a single TLMOptions object for single prompt.\n"
+                    "See: https://help.cleanlab.ai/reference/python/trustworthy_language_model/#class-tlmoptions"
+                )
 
             return self._event_loop.run_until_complete(
                 self.prompt_async(
@@ -303,7 +306,10 @@ class TLM:
 
         elif isinstance(prompt, str):
             if not (options is None or isinstance(options, dict)):
-                raise ValueError("options must be a single TLMOptions object for single prompt.")
+                raise ValueError(
+                    "options must be a single TLMOptions object for single prompt.\n"
+                    "See: https://help.cleanlab.ai/reference/python/trustworthy_language_model/#class-tlmoptions"
+                )
 
             if not isinstance(response, str):
                 raise ValueError("responses must be a single string for single prompt.")

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -211,10 +211,9 @@ class TLM:
             if not isinstance(options, dict):
                 raise ValueError("options must be a single TLMOptions object for single prompt.")
 
-            prompt = cast(str, prompt)
             return self._event_loop.run_until_complete(
                 self.prompt_async(
-                    cast(str, prompt),
+                    prompt,
                     cast(Union[None, TLMOptions], options),
                     retries=retries,
                 )
@@ -296,16 +295,13 @@ class TLM:
             if not isinstance(response, str):
                 raise ValueError("responses must be a single string for single prompt.")
 
-            return cast(
-                float,
-                self._event_loop.run_until_complete(
-                    self.get_confidence_score_async(
-                        cast(str, prompt),
-                        response,
-                        cast(Union[None, TLMOptions], options),
-                        retries=retries,
-                    )
-                ),
+            return self._event_loop.run_until_complete(
+                self.get_confidence_score_async(
+                    prompt,
+                    response,
+                    cast(Union[None, TLMOptions], options),
+                    retries=retries,
+                )
             )
 
         else:

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -100,11 +100,11 @@ class TLM:
         Returns:
             List[TLMResponse]: TLM responses for each prompt (in supplied order)
         """
-        if not is_collection(options):
+        if is_collection(options):
+            options_collection = cast(Collection[Union[TLMOptions, None]], options)
+        else:
             options = cast(Union[None, TLMOptions], options)
             options_collection = [options for _ in prompts]
-        else:
-            options_collection = cast(Collection[Union[TLMOptions, None]], options)
 
         assert len(prompts) == len(options_collection), "Length of prompts and options must match."
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -278,8 +278,8 @@ class TLM:
         """Gets confidence score for prompt-response pair(s).
 
         Args:
-            prompt (str | List[str]): prompt (or list/iterable of multiple prompts) for the TLM
-            response (str | List[str]): response (or list/iterable of multiple responses) for the TLM to evaluate
+            prompt (str | List[str]): prompt (or list of multiple prompts) for the TLM
+            response (str | List[str]): response (or list of multiple responses) for the TLM to evaluate
             options (None | TLMOptions | List[TLMOptions  |  None], optional): list of options (or instance of options) to pass to get confidence score method. Defaults to None.
             timeout (Optional[float], optional): maximum allowed time (in seconds) to run all prompts and evaluate all responses. Defaults to None.
                 If the timeout is hit, this method will throw a `TimeoutError`.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -144,11 +144,11 @@ class TLM:
         Returns:
             List[float]: TLM confidence score for each prompt (in supplied order)
         """
-        if not is_collection(options):
+        if is_collection(options):
+            options_collection = cast(Collection[Union[TLMOptions, None]], options)
+        else:
             options = cast(Union[None, TLMOptions], options)
             options_collection = [options for _ in prompts]
-        else:
-            options_collection = cast(Collection[Union[TLMOptions, None]], options)
 
         assert len(prompts) == len(responses), "Length of prompts and responses must match."
         assert len(prompts) == len(options_collection), "Length of prompts and options must match."

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -215,7 +215,7 @@ class TLM:
             )
 
         elif isinstance(prompt, str):
-            if not isinstance(options, dict):
+            if not (options is None or isinstance(options, dict)):
                 raise ValueError("options must be a single TLMOptions object for single prompt.")
 
             return self._event_loop.run_until_complete(
@@ -303,7 +303,7 @@ class TLM:
             )
 
         elif isinstance(prompt, str):
-            if not isinstance(options, dict):
+            if not (options is None or isinstance(options, dict)):
                 raise ValueError("options must be a single TLMOptions object for single prompt.")
 
             if not isinstance(response, str):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -194,16 +194,17 @@ class TLM:
         Args:
             prompt (str | Collection[str]): prompt (or list/iterable of multiple prompts) for the TLM
             options (None | TLMOptions | Collection[TLMOptions |  None], optional): collection of options (or instance of options) to pass to prompt method. Defaults to None.
-            timeout (Optional[float], optional): maximum allowed time (in seconds) to run all prompts. Defaults to None.
+            timeout (Optional[float], optional): timeout (in seconds) to run all prompts. Defaults to None.
                 If the timeout is hit, this method will throw a `TimeoutError`.
                 Larger values give TLM a higher chance to return outputs for all of your prompts.
                 Smaller values ensure this method does not take too long.
-            retries (int): number of retries to attempt for each individual prompt in case of error. Defaults to 1.
+            retries (int): number of retries to attempt for each individual prompt in case of internal error. Defaults to 1.
                 Larger values give TLM a higher chance of returning outputs for all of your prompts,
                 but this method will also take longer to alert you in cases of an unrecoverable error.
                 Set to 0 to never attempt any retries.
         Returns:
-            TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and confidence score
+            TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and confidence score.
+                    If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.
         """
         if is_collection(prompt):
             return self._batch_prompt(
@@ -275,16 +276,17 @@ class TLM:
             prompt (str | Collection[str]): prompt (or list/iterable of multiple prompts) for the TLM
             response (str | Collection[str]): response (or list/iterable of multiple responses) for the TLM to evaluate
             options (None | TLMOptions | List[TLMOptions  |  None], optional): list of options (or instance of options) to pass to get confidence score method. Defaults to None.
-            timeout (Optional[float], optional): timeout (in seconds) to run all prompts. Defaults to None.
+            timeout (Optional[float], optional): maximum allowed time (in seconds) to run all prompts and evaluate all responses. Defaults to None.
                 If the timeout is hit, this method will throw a `TimeoutError`.
-                Larger values give TLM a higher chance to return outputs for all of your prompts.
+                Larger values give TLM a higher chance to return outputs for all of your prompts + responses.
                 Smaller values ensure this method does not take too long.
-            retries (int): number of retries to attempt for each individual prompt in case of error. Defaults to 1.
+            retries (int): number of retries to attempt for each individual prompt in case of internal error. Defaults to 1.
                 Larger values give TLM a higher chance of returning outputs for all of your prompts,
                 but this method will also take longer to alert you in cases of an unrecoverable error.
                 Set to 0 to never attempt any retries.
         Returns:
-            float or list of floats corresponding to the TLM's confidence score
+            float (or list of floats if multiple prompt-responses were provided) corresponding to the TLM's confidence score.
+                    The score quantifies how confident TLM is that the given response is good for the given prompt.
         """
         if is_collection(prompt):
             if not is_collection(response):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -206,6 +206,9 @@ class TLM:
                     If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.
         """
         if isinstance(prompt, list):
+            if any(not isinstance(p, str) for p in prompt):
+                raise ValueError("All prompts must be strings.")
+
             return self._batch_prompt(
                 prompt,
                 options,
@@ -229,7 +232,7 @@ class TLM:
             )
 
         else:
-            raise ValueError("prompt must be a string or list/iterable of strings.")
+            raise ValueError("prompt must be a string or list of strings.")
 
     async def prompt_async(
         self,
@@ -291,6 +294,11 @@ class TLM:
                     The score quantifies how confident TLM is that the given response is good for the given prompt.
         """
         if isinstance(prompt, list):
+            if any(not isinstance(p, str) for p in prompt):
+                raise ValueError("All prompts must be strings.")
+            if any(not isinstance(r, str) for r in response):
+                raise ValueError("All responses must be strings.")
+
             if not isinstance(response, list):
                 raise ValueError(
                     "responses must be a list or iterable of strings when prompt is a list or iterable."


### PR DESCRIPTION
Two main changes:
- Refactors TLM API to use `prompt` and `get_confidence_score` as batch methods
  - `batch_prompt` and `batch_get_confidence_score` kept for reverse compatibility
- Refine retries
  - Don't deduct from retry count when hitting the rate limit
  - Set default retries to nonzero (now set to 1)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206627753448625