### PR TITLE
add deprecation warnings and schema override conversion

### DIFF
--- a/cleanlab_studio/cli/api_service.py
+++ b/cleanlab_studio/cli/api_service.py
@@ -2,6 +2,7 @@
 Methods for interacting with the command line server API
 1:1 mapping with command_line_api.py
 """
+
 import os
 from typing import List, Optional
 

--- a/cleanlab_studio/cli/click_helpers.py
+++ b/cleanlab_studio/cli/click_helpers.py
@@ -7,6 +7,7 @@ Progress status: blue
 Information: default
 Success/completion: green
 """
+
 import os
 
 import click

--- a/cleanlab_studio/cli/dataset/schema_helpers.py
+++ b/cleanlab_studio/cli/dataset/schema_helpers.py
@@ -1,6 +1,7 @@
 """
 Helper functions for working with schemas
 """
+
 import json
 from typing import Any, cast, List
 

--- a/cleanlab_studio/cli/util.py
+++ b/cleanlab_studio/cli/util.py
@@ -1,6 +1,7 @@
 """
 Contains utility functions for interacting with dataset files
 """
+
 import io
 import json
 import os

--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -38,3 +38,7 @@ class InternalError(Exception):
 
 class CleansetError(InternalError):
     pass
+
+
+class InvalidSchemaTypeError(ValueError):
+    pass

--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -41,4 +41,8 @@ class CleansetError(InternalError):
 
 
 class InvalidSchemaTypeError(ValueError):
-    pass
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"{self.msg}\nSee [TODO: insert docs] link for more information."

--- a/cleanlab_studio/internal/upload_helpers.py
+++ b/cleanlab_studio/internal/upload_helpers.py
@@ -12,6 +12,7 @@ from requests.adapters import HTTPAdapter, Retry
 from .api import api
 from .dataset_source import DatasetSource
 from .types import JSONDict, SchemaOverride
+from errors import InvalidSchemaTypeError
 
 
 def upload_dataset(
@@ -141,7 +142,7 @@ def _old_schema_to_column_type(data_type: str, feature_type: str) -> str:
         return _float_data_type_to_column_type(data_type, feature_type)
     if data_type == "boolean":
         return _boolean_data_type_to_column_type(data_type, feature_type)
-    raise ValueError(f"Unsupported data type: {data_type}.")
+    raise InvalidSchemaTypeError(f"Unsupported data type: {data_type}.")
 
 
 def _string_data_type_to_column_type(data_type: str, feature_type: str) -> str:
@@ -150,10 +151,10 @@ def _string_data_type_to_column_type(data_type: str, feature_type: str) -> str:
     if feature_type == "image":
         return "image_external"
     if feature_type in ["datetime", "identifier"]:
-        raise ValueError(
+        raise InvalidSchemaTypeError(
             f"Cannot convert old schema feature type '{feature_type}' to new schema type."
         )
-    raise ValueError(
+    raise InvalidSchemaTypeError(
         f"Unsupported data type, feature type combination: {data_type}, {feature_type}."
     )
 
@@ -162,10 +163,10 @@ def _integer_data_type_to_column_type(data_type: str, feature_type: str) -> str:
     if feature_type in ["categorical", "numeric"]:
         return "integer"
     if feature_type in ["datetime", "identifier"]:
-        raise ValueError(
+        raise InvalidSchemaTypeError(
             f"Cannot convert old schema feature type '{feature_type}' to new schema type."
         )
-    raise ValueError(
+    raise InvalidSchemaTypeError(
         f"Unsupported data type, feature type combination: {data_type}, {feature_type}."
     )
 
@@ -174,10 +175,10 @@ def _float_data_type_to_column_type(data_type: str, feature_type: str) -> str:
     if feature_type == "numeric":
         return "float"
     if feature_type == "datetime":
-        raise ValueError(
+        raise InvalidSchemaTypeError(
             f"Cannot convert old schema feature type '{feature_type}' to new schema type."
         )
-    raise ValueError(
+    raise InvalidSchemaTypeError(
         f"Unsupported data type, feature type combination: {data_type}, {feature_type}."
     )
 
@@ -185,6 +186,6 @@ def _float_data_type_to_column_type(data_type: str, feature_type: str) -> str:
 def _boolean_data_type_to_column_type(data_type: str, feature_type: str) -> str:
     if feature_type == "boolean":
         return "boolean"
-    raise ValueError(
+    raise InvalidSchemaTypeError(
         f"Unsupported data type, feature type combination: {data_type}, {feature_type}."
     )

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -83,10 +83,12 @@ class Studio:
         if kwargs.get("modality") is not None:
             warnings.warn(
                 "Ignoring `modality` parameter which is deprecated and will be removed in a future release.",
+                FutureWarning,
             )
         if kwargs.get("id_column") is not None:
             warnings.warn(
                 "Ignoring `id_column` parameter which is deprecated and will be removed in a future release.",
+                FutureWarning,
             )
 
         if isinstance(schema_overrides, dict):
@@ -94,6 +96,7 @@ class Studio:
             schema_overrides = upload_helpers.convert_schema_overrides(schema_overrides)
             warnings.warn(
                 "Using deprecated `schema_overrides` format. Please use list of SchemaOverride objects instead.",
+                FutureWarning,
             )
 
         return upload_helpers.upload_dataset(

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -31,8 +31,6 @@ _pyspark_exists = api.pyspark_exists
 if _pyspark_exists:
     import pyspark.sql
 
-warnings.simplefilter("always", DeprecationWarning)
-
 
 class Studio:
     """Used to interact with Cleanlab Studio."""
@@ -85,21 +83,18 @@ class Studio:
         if kwargs.get("modality") is not None:
             warnings.warn(
                 "Ignoring `modality` parameter which is deprecated and will be removed in a future release.",
-                DeprecationWarning,
             )
         if kwargs.get("id_column") is not None:
             warnings.warn(
                 "Ignoring `id_column` parameter which is deprecated and will be removed in a future release.",
-                DeprecationWarning,
             )
 
         if isinstance(schema_overrides, dict):
             # TODO: link to documentation for schema override format
+            schema_overrides = upload_helpers.convert_schema_overrides(schema_overrides)
             warnings.warn(
                 "Using deprecated `schema_overrides` format. Please use list of SchemaOverride objects instead.",
-                DeprecationWarning,
             )
-            schema_overrides = upload_helpers.convert_schema_overrides(schema_overrides)
 
         return upload_helpers.upload_dataset(
             self._api_key,

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -1,6 +1,7 @@
 """
 Cleanlab TLM is a Large Language Model that gives more reliable answers and quantifies its uncertainty in these answers
 """
+
 import asyncio
 import sys
 from typing import Coroutine, cast, List, Literal, Optional, TypedDict, Union


### PR DESCRIPTION
- Adds deprecation warnings if a user provides `id_column` or `modality` kwargs to the `upload_dataset` method
- Adds a deprecation warning if a user provides `schema_overrides` in the old format
- Attempts to convert old `schema_overrides` format to new format
  - If feature_type is "datetime" or "identifier", raises error
  - If data_type, feature_type combination is invalid in old schema format, raises error

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206603310631125