### PR TITLE
[TLM upgrade] Add model type to initi params

### DIFF
--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -4,3 +4,4 @@ from typing import List
 _DEFAULT_MAX_CONCURRENT_TLM_REQUESTS: int = 16
 _MAX_CONCURRENT_TLM_REQUESTS_LIMIT: int = 128
 _VALID_TLM_QUALITY_PRESETS: List[str] = ["best", "high", "medium", "low", "base"]
+_VALID_TLM_MODELS: List[str] = ["gpt-3.5-turbo-16k", "gpt-4"]

--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -5,3 +5,6 @@ _DEFAULT_MAX_CONCURRENT_TLM_REQUESTS: int = 16
 _MAX_CONCURRENT_TLM_REQUESTS_LIMIT: int = 128
 _VALID_TLM_QUALITY_PRESETS: List[str] = ["best", "high", "medium", "low", "base"]
 _VALID_TLM_MODELS: List[str] = ["gpt-3.5-turbo-16k", "gpt-4"]
+_MUTABLE_PARAMS_SET_AT_INIT: List[str] = [
+    "model"
+]  # params that can be set at init of TLM object but also specified in the options dictionary during prompting

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -374,18 +374,24 @@ class Studio:
         self,
         *,
         quality_preset: trustworthy_language_model.QualityPreset = "medium",
+        model: trustworthy_language_model.TLMModel = "gpt-3.5-turbo-16k",
         **kwargs: Any,
     ) -> trustworthy_language_model.TLM:
         """Gets Trustworthy Language Model (TLM) object to prompt.
 
-        Args:
-            quality_preset: quality preset to use for prompts
-            kwargs (Any): additional kwargs to pass to TLM class
+        Parameters
+        ----------
+            quality_preset: QualityPreset, default = "low"
+                Quality preset to use for TLM queries
+            model: TLMModel, default = "gpt-3.5-turbo-16k"
+                ID of the model to use. Other options: "gpt-4"
+            kwargs (Any):
+                Additional kwargs to pass to TLM class
 
         Returns:
             TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
         """
-        return trustworthy_language_model.TLM(self._api_key, quality_preset, **kwargs)
+        return trustworthy_language_model.TLM(self._api_key, quality_preset, model, **kwargs)
 
     def poll_cleanset_status(self, cleanset_id: str, timeout: Optional[int] = None) -> bool:
         """

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -25,7 +25,7 @@ from cleanlab_studio.internal.util import (
     apply_corrections_pd_df,
 )
 from cleanlab_studio.internal.settings import CleanlabSettings
-from cleanlab_studio.internal.types import FieldSchemaDict, TLMQualityPreset
+from cleanlab_studio.internal.types import FieldSchemaDict, TLMQualityPreset, TLMModel
 from cleanlab_studio.errors import VersionError, MissingAPIKeyError, InvalidDatasetError
 
 _snowflake_exists = api.snowflake_exists
@@ -374,7 +374,7 @@ class Studio:
         self,
         *,
         quality_preset: TLMQualityPreset = "medium",
-        model: trustworthy_language_model.TLMModel = "gpt-3.5-turbo-16k",
+        model: TLMModel = "gpt-3.5-turbo-16k",
         **kwargs: Any,
     ) -> trustworthy_language_model.TLM:
         """Gets Trustworthy Language Model (TLM) object to prompt.

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -378,15 +378,11 @@ class Studio:
         **kwargs: Any,
     ) -> trustworthy_language_model.TLM:
         """Gets Trustworthy Language Model (TLM) object to prompt.
-
-        Parameters
-        ----------
-            quality_preset: QualityPreset, default = "low"
-                Quality preset to use for TLM queries
-            model: TLMModel, default = "gpt-3.5-turbo-16k"
-                ID of the model to use. Other options: "gpt-4"
-            kwargs (Any):
-                Additional kwargs to pass to TLM class
+        
+        Args:
+            quality_preset: quality preset to use for prompts
+            model (str, default="gpt-3.5-turbo-16k"): ID of the model to use. Other options: "gpt-4"
+            kwargs (Any): additional kwargs to pass to TLM class
 
         Returns:
             TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -17,6 +17,9 @@ from cleanlab_studio.internal.types import JSONDict
 valid_quality_presets = ["best", "high", "medium", "low", "base"]
 QualityPreset = Literal["best", "high", "medium", "low", "base"]
 
+valid_tlm_models = ["gpt-3.5-turbo-16k", "gpt-4"]
+TLMModel = Literal["gpt-3.5-turbo-16k", "gpt-4"]
+
 DEFAULT_MAX_CONCURRENT_TLM_REQUESTS: int = 16
 MAX_CONCURRENT_TLM_REQUESTS_LIMIT: int = 128
 
@@ -80,14 +83,21 @@ class TLM:
         self,
         api_key: str,
         quality_preset: QualityPreset,
+        model: TLMModel,
         max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_TLM_REQUESTS,
     ) -> None:
         """Initializes TLM interface.
 
-        Args:
-            api_key (str): API key used to authenticate TLM client
-            quality_preset (QualityPreset): quality preset to use for TLM queries
-            max_concurrent_requests (int): maximum number of concurrent requests when issuing batch queries. Default is 16.
+        Parameters
+        ----------
+            api_key: str
+                API key used to authenticate TLM client
+            quality_preset: QualityPreset, default = "low"
+                Quality preset to use for TLM queries
+            max_concurrent_requests: int, default = 16
+                Maximum number of concurrent requests when issuing batch queries.
+            model: TLMModel, default = "gpt-3.5-turbo-16k"
+                ID of the model to use. Other options: "gpt-4"
         """
         self._api_key = api_key
 
@@ -101,6 +111,10 @@ class TLM:
             )
 
         self._quality_preset = quality_preset
+
+        if model not in valid_tlm_models:
+            raise ValueError(f"Invalid model {model} -- must be one of {valid_tlm_models}")
+        self._model = model
 
         if is_notebook():
             import nest_asyncio

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -12,15 +12,14 @@ import aiohttp
 from typing_extensions import NotRequired, TypedDict  # for Python <3.11 with (Not)Required
 
 from cleanlab_studio.internal.api import api
-from cleanlab_studio.internal.types import JSONDict, TLMQualityPreset
+from cleanlab_studio.internal.types import JSONDict, TLMQualityPreset, TLMModel
 from cleanlab_studio.internal.constants import (
     _DEFAULT_MAX_CONCURRENT_TLM_REQUESTS,
     _MAX_CONCURRENT_TLM_REQUESTS_LIMIT,
     _VALID_TLM_QUALITY_PRESETS,
+    _VALID_TLM_MODELS,
 )
 
-valid_tlm_models = ["gpt-3.5-turbo-16k", "gpt-4"]
-TLMModel = Literal["gpt-3.5-turbo-16k", "gpt-4"]
 
 class TLMResponse(TypedDict):
     """Trustworthy Language Model response.
@@ -98,8 +97,8 @@ class TLM:
 
         self._quality_preset = quality_preset
 
-        if model not in valid_tlm_models:
-            raise ValueError(f"Invalid model {model} -- must be one of {valid_tlm_models}")
+        if model not in _VALID_TLM_MODELS:
+            raise ValueError(f"Invalid model {model} -- must be one of {_VALID_TLM_MODELS}")
         self._model = model
 
         if is_notebook():


### PR DESCRIPTION
This PR changes how we handle the options dictionary w..r.t. parameters set during initialization and introduces a new parameter that can be set during initialization: `model`. 

How we handle options dictionary for a specific key in options dictionary that has a matching parameter that could be set during initialization:
- if key is passed in during prompt, it overrides that param set at initialization
- if no param set during initialization or passed into options dictionary, defaults values used
- otherwise, use param set during initialization