### PR TITLE
[upload v1] support schema overrides during initial upload

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -120,9 +120,13 @@ def complete_file_upload(api_key: str, upload_id: str, upload_parts: List[JSONDi
     handle_api_error(res)
 
 
-def confirm_upload(api_key: str, upload_id: str) -> None:
+def confirm_upload(
+    api_key: str,
+    upload_id: str,
+    schema_overrides: Optional[List[SchemaOverride]],
+) -> None:
     check_uuid_well_formed(upload_id, "upload ID")
-    request_json = dict(upload_id=upload_id)
+    request_json = dict(upload_id=upload_id, schema_overrides=schema_overrides)
     res = requests.post(
         f"{upload_base_url}/confirm",
         json=request_json,

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -413,7 +413,7 @@ def poll_ingestion_progress(api_key: str, upload_id: str, description: str) -> s
 
     # get dataset ID
     dataset_id = get_dataset_id(api_key, upload_id)["dataset_id"]
-    return dataset_id
+    return str(dataset_id)
 
 
 def upload_predict_batch(api_key: str, model_id: str, batch: io.StringIO) -> str:

--- a/cleanlab_studio/internal/upload_helpers.py
+++ b/cleanlab_studio/internal/upload_helpers.py
@@ -12,7 +12,7 @@ from requests.adapters import HTTPAdapter, Retry
 from .api import api
 from .dataset_source import DatasetSource
 from .types import JSONDict, SchemaOverride
-from errors import InvalidSchemaTypeError
+from cleanlab_studio.errors import InvalidSchemaTypeError
 
 
 def upload_dataset(
@@ -25,19 +25,10 @@ def upload_dataset(
     upload_id = upload_dataset_file(api_key, dataset_source)
 
     # confirm upload (and kick off processing)
-    api.confirm_upload(api_key, upload_id)
+    api.confirm_upload(api_key, upload_id, schema_overrides)
 
     # wait for dataset upload
     dataset_id = api.poll_ingestion_progress(api_key, upload_id, "Ingesting Dataset...")
-
-    # if schema overrides, update schema and wait for reingestion
-    if schema_overrides:
-        api.update_schema(
-            api_key,
-            dataset_id,
-            schema_overrides,
-        )
-        api.poll_ingestion_progress(api_key, upload_id, "Updating Schema...")
 
     # return dataset id
     return dataset_id


### PR DESCRIPTION
- include schema overrides as part of confirm upload instead of requiring additional schema ingestion
- check for error status when polling ingestion progress

Test with [associated backend changes](https://github.com/cleanlab/cleanlab-studio-backend/pull/1211)