### PR TITLE
Fix - populate final label in apply_corrections_pd_df with fillna

### DIFF
--- a/cleanlab_studio/internal/util.py
+++ b/cleanlab_studio/internal/util.py
@@ -182,10 +182,7 @@ def apply_corrections_pd_df(
         joined_ds = dataset.join(cl_cols.set_index(id_col), on=id_col)
     else:
         joined_ds = dataset.join(cl_cols.set_index(id_col).sort_values(by=id_col))
-    joined_ds["__cleanlab_final_label"] = joined_ds["corrected_label"].where(
-        joined_ds["corrected_label"].notnull().tolist(),
-        dataset[label_column].tolist(),
-    )
+    joined_ds["__cleanlab_final_label"] = joined_ds["corrected_label"].fillna(dataset[label_column])
 
     corrected_ds: pd.DataFrame = dataset.copy()
     corrected_ds[label_column] = joined_ds["__cleanlab_final_label"]


### PR DESCRIPTION
Bug fix:
Currently when the `apply_corrections_pd_df` function is called where the label column is of type integer, then it'll throw `TypeError: only integer scalar arrays can be converted to a scalar index`. It appears this error is due to the use of `.tolist()` method on a pandas Series that is being used as an indexer. In pandas, when you use a Series or a list as an indexer, it expects the list or Series to be of boolean type, not integer. 

solution:
The `where` function here is used to replace values where the condition is `False`, because we are replacing null values in the `corrected_label` column with the corresponding values from the `label_column` of the dataset. We can achieve this instead by using the `fillna` function. 