### PR TITLE
Patch: dont retry tlm 4XXs

### DIFF
--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -52,7 +52,7 @@ class RateLimitError(APIError):
         self.retry_after = retry_after
 
 
-class TlmQueryTooLargeError(APIError):
+class TlmBadRequest(APIError):
     pass
 
 

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -86,7 +86,7 @@ async def handle_tlm_client_error_from_resp(resp: aiohttp.ClientResponse) -> Non
         except Exception:
             error_message = "Client error occurred."
 
-        raise APIError(error_message)
+        raise TlmBadRequest(error_message)
 
 
 def validate_api_key(api_key: str) -> bool:


### PR DESCRIPTION
Raise 4XXs from TLM immediately, don't retry

---

Testing:
Run the TLM, providing invalid options. TLM should fail ~immediately without retrying, with a `TlmBadRequest` error type:

E.g:
```
tlm = Studio("<API_KEY>").TLM()
tlm.prompt("2+2?", options={"some_invalid_option": 123})
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206649294650263