### PR TITLE
Update TLM API

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -511,7 +511,6 @@ async def tlm_prompt(
     prompt: str,
     quality_preset: str,
     options: Optional[JSONDict],
-    client_session: Optional[aiohttp.ClientSession] = None,
 ) -> JSONDict:
     """
     Prompt Trustworthy Language Model with a question, and get back its answer along with a confidence score
@@ -526,10 +525,7 @@ async def tlm_prompt(
     Returns:
         JSONDict: dictionary with TLM response and confidence score
     """
-    local_scoped_client = False
-    if not client_session:
-        client_session = aiohttp.ClientSession()
-        local_scoped_client = True
+    client_session = aiohttp.ClientSession()
 
     try:
         res = await client_session.post(
@@ -544,8 +540,7 @@ async def tlm_prompt(
         handle_api_error_from_json(res_json)
 
     finally:
-        if local_scoped_client:
-            await client_session.close()
+        await client_session.close()
 
     return cast(JSONDict, res_json)
 
@@ -557,7 +552,6 @@ async def tlm_get_confidence_score(
     response: str,
     quality_preset: str,
     options: Optional[JSONDict],
-    client_session: Optional[aiohttp.ClientSession] = None,
 ) -> JSONDict:
     """
     Query Trustworthy Language Model for a confidence score for the prompt-response pair.
@@ -568,15 +562,11 @@ async def tlm_get_confidence_score(
         response (str): response for TLM to get confidence score for
         quality_preset (str): quality preset to use to generate confidence score
         options (JSONDict): additional parameters for TLM
-        client_session (aiohttp.ClientSession): client session used to issue TLM request
 
     Returns:
         JSONDict: dictionary with TLM confidence score
     """
-    local_scoped_client = False
-    if not client_session:
-        client_session = aiohttp.ClientSession()
-        local_scoped_client = True
+    client_session = aiohttp.ClientSession()
 
     try:
         res = await client_session.post(
@@ -588,15 +578,11 @@ async def tlm_get_confidence_score(
         )
         res_json = await res.json()
 
-        if local_scoped_client:
-            await client_session.close()
-
         await handle_tlm_client_error_from_resp(res)
         handle_rate_limit_error_from_resp(res)
         handle_api_error_from_json(res_json)
 
     finally:
-        if local_scoped_client:
-            await client_session.close()
+        await client_session.close()
 
     return cast(JSONDict, res_json)

--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -2,5 +2,5 @@ from typing import List
 
 # prepend constants with _ so that they don't show up in help.cleanlab.ai docs
 _DEFAULT_MAX_CONCURRENT_TLM_REQUESTS: int = 16
-_MAX_CONCURRENT_TLM_REQUESTS_LIMIT: int = 128
 _VALID_TLM_QUALITY_PRESETS: List[str] = ["best", "high", "medium", "low", "base"]
+_TLM_MAX_RETRIES: int = 10  # TODO: finalize this number

--- a/cleanlab_studio/internal/tlm_helpers.py
+++ b/cleanlab_studio/internal/tlm_helpers.py
@@ -1,0 +1,37 @@
+from typing import Union, Sequence
+
+
+def validate_tlm_prompt(prompt: Union[str, Sequence[str]]) -> None:
+    if isinstance(prompt, str):
+        return
+
+    elif isinstance(prompt, Sequence):
+        if any(not isinstance(p, str) for p in prompt):
+            raise ValueError("All prompts must be strings.")
+
+    else:
+        raise ValueError("prompt must be a string or list of strings.")
+
+
+def validate_tlm_prompt_response(
+    prompt: Union[str, Sequence[str]], response: Union[str, Sequence[str]]
+) -> None:
+    if isinstance(prompt, str):
+        if not isinstance(response, str):
+            raise ValueError("responses must be a single string for single prompt.")
+
+    elif isinstance(prompt, Sequence):
+        if not isinstance(response, Sequence):
+            raise ValueError(
+                "responses must be a list or iterable of strings when prompt is a list or iterable."
+            )
+        if len(prompt) != len(response):
+            raise "Length of prompt and response must match."
+
+        if any(not isinstance(p, str) for p in prompt):
+            raise ValueError("All prompts must be strings.")
+        if any(not isinstance(r, str) for r in response):
+            raise ValueError("All responses must be strings.")
+
+    else:
+        raise ValueError("prompt must be a string or list/iterable of strings.")

--- a/cleanlab_studio/internal/tlm_helpers.py
+++ b/cleanlab_studio/internal/tlm_helpers.py
@@ -26,7 +26,7 @@ def validate_tlm_prompt_response(
                 "responses must be a list or iterable of strings when prompt is a list or iterable."
             )
         if len(prompt) != len(response):
-            raise "Length of prompt and response must match."
+            raise ValueError("Length of prompt and response must match.")
 
         if any(not isinstance(p, str) for p in prompt):
             raise ValueError("All prompts must be strings.")

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -375,9 +375,11 @@ class Studio:
 
     def TLM(
         self,
-        *,
         quality_preset: TLMQualityPreset = "medium",
-        **kwargs: Any,
+        *,
+        options: Optional[trustworthy_language_model.TLMOptions] = None,
+        timeout: Optional[float] = None,
+        verbose: Optional[bool] = None,
     ) -> trustworthy_language_model.TLM:
         """Gets Trustworthy Language Model (TLM) object to prompt.
 
@@ -388,7 +390,9 @@ class Studio:
         Returns:
             TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
         """
-        return trustworthy_language_model.TLM(self._api_key, quality_preset, **kwargs)
+        return trustworthy_language_model.TLM(
+            self._api_key, quality_preset, options=options, timeout=timeout, verbose=verbose
+        )
 
     def poll_cleanset_status(self, cleanset_id: str, timeout: Optional[int] = None) -> bool:
         """


### PR DESCRIPTION
Key changes:
- removes arguments `max_concurrent_request`, `retries`, `max_timeout`
- move some arguments to be set during initialization, such as `options`, `timeout`
  - adds a new argument `verbose`
- allow batching for async methods
- rename `get_confidence_score` -> `get_trustworthiness_score` 