### PR TITLE
Hotfix: rate limit error precedence

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -539,8 +539,8 @@ async def tlm_prompt(
         )
         res_json = await res.json()
 
-        await handle_tlm_client_error_from_resp(res)
         handle_rate_limit_error_from_resp(res)
+        await handle_tlm_client_error_from_resp(res)
         handle_api_error_from_json(res_json)
 
     finally:
@@ -591,8 +591,8 @@ async def tlm_get_confidence_score(
         if local_scoped_client:
             await client_session.close()
 
-        await handle_tlm_client_error_from_resp(res)
         handle_rate_limit_error_from_resp(res)
+        await handle_tlm_client_error_from_resp(res)
         handle_api_error_from_json(res_json)
 
     finally:


### PR DESCRIPTION
handle rate limits before tlm client errors
(ensure rate limits get retried

Fixes bug introduced https://github.com/cleanlab/cleanlab-studio/pull/193