### PR TITLE
updates label column validation to account for regression task type

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -199,9 +199,16 @@ class Studio:
         dataset_details = api.get_dataset_details(self._api_key, dataset_id, task_type)
 
         if label_column is not None:
-            if label_column not in dataset_details["label_columns"]:
+            if label_column not in dataset_details["label_columns"] and task_type != "regression":
                 raise InvalidDatasetError(
                     f"Invalid label column: {label_column}. Label column must have categorical feature type"
+                )
+            if (
+                label_column not in dataset_details["possible_numeric_columns"]
+                and task_type == "regression"
+            ):
+                raise InvalidDatasetError(
+                    f"Invalid target column: {label_column}. Regression target column must have numerical feature type"
                 )
         elif task_type is not None and task_type != "unsupervised":
             label_column = str(dataset_details["label_column_guess"])


### PR DESCRIPTION
@mturk24 ran into a bug where creating a regression project with a specified `label_column` would throw an error for valid target columns because they weren't categorical type.

This checks the column's appropriateness correctly.

Relies on this backend PR to work: https://github.com/cleanlab/cleanlab-studio-backend/pull/1317