### PR TITLE
add better validation for project label column

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -323,6 +323,28 @@ def get_dataset_details(api_key: str, dataset_id: str, task_type: Optional[str])
     return dataset_details
 
 
+def check_column_diversity(api_key: str, dataset_id: str, column_name: str) -> JSONDict:
+    check_uuid_well_formed(dataset_id, "dataset ID")
+    res = requests.get(
+        dataset_base_url + f"/diversity/{dataset_id}/{column_name}",
+        headers=_construct_headers(api_key),
+    )
+    handle_api_error(res)
+    column_diversity: JSONDict = res.json()
+    return column_diversity
+
+
+def is_valid_multilabel_column(api_key: str, dataset_id: str, column_name: str) -> bool:
+    check_uuid_well_formed(dataset_id, "dataset ID")
+    res = requests.get(
+        dataset_base_url + f"/check_valid_multilabel/{dataset_id}/{column_name}",
+        headers=_construct_headers(api_key),
+    )
+    handle_api_error(res)
+    multilabel_column: JSONDict = res.json()
+    return bool(multilabel_column["is_valid_multilabel_column"])
+
+
 def clean_dataset(
     api_key: str,
     dataset_id: str,

--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -1,10 +1,10 @@
 import itertools
 import time
-from typing import Optional
+from typing import List, Optional
 
 from tqdm import tqdm
 
-from cleanlab_studio.errors import CleansetError
+from cleanlab_studio.errors import CleansetError, InvalidDatasetError
 from cleanlab_studio.internal.api import api
 
 
@@ -53,3 +53,43 @@ def poll_cleanset_status(
         if res["has_error"]:
             pbar.set_postfix_str(res["step_description"])
             raise CleansetError(f"Cleanset {cleanset_id} failed to complete")
+
+
+def validate_label_column(
+    api_key: str,
+    dataset_id: str,
+    label_column: str,
+    modality: str,
+    task_type: str,
+    possible_label_columns: List[str],
+) -> None:
+    if label_column not in possible_label_columns:
+        if task_type == "multi-class":
+            valid_types = ["string", "integer", "boolean"]
+        if task_type == "multi-label":
+            valid_types = ["string"]
+        if task_type == "regression":
+            valid_types = ["float"]
+
+        raise InvalidDatasetError(
+            (
+                f"Invalid label column: {label_column}. "
+                f"{task_type.capitalize()} projects require a label column of type {', '.join(valid_types)}. "
+                "Also ensure that the column has at least 2 unique values."
+            )
+        )
+    if task_type == "multi-class":
+        column_diversity = api.check_column_diversity(api_key, dataset_id, label_column)
+        if (
+            modality != "text"
+            and modality != "image"
+            and not column_diversity["has_minimal_diversity"]
+        ):
+            raise InvalidDatasetError(
+                "Label column for multi-class projects must have at least 2 unique classes with at least 5 examples each."
+            )
+    if task_type == "multi-label":
+        if not api.is_valid_multilabel_column(api_key, dataset_id, label_column):
+            raise InvalidDatasetError(
+                'Label column for multi-label projects should be formatted as comma-separated string of labels, i.e. "wearing_hat,has_glasses"'
+            )

--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -1,6 +1,6 @@
 import itertools
 import time
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from tqdm import tqdm
 
@@ -59,8 +59,8 @@ def validate_label_column(
     api_key: str,
     dataset_id: str,
     label_column: str,
-    modality: str,
-    task_type: str,
+    modality: Literal["text", "tabular", "image"],
+    task_type: Optional[Literal["multi-class", "multi-label", "regression", "unsupervised"]],
     possible_label_columns: List[str],
 ) -> None:
     if label_column not in possible_label_columns:

--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -75,6 +75,7 @@ def validate_label_column(
             (
                 f"Invalid label column: {label_column}. "
                 f"{str(task_type).capitalize()} projects require a label column of type {', '.join(valid_types)}. "
+                "For details on how to set the schema for your dataset, see the [datasets guide](/guide/concepts/datasets/#schema-updates). "
                 "Also ensure that the column has at least 2 unique values."
             )
         )

--- a/cleanlab_studio/internal/clean_helpers.py
+++ b/cleanlab_studio/internal/clean_helpers.py
@@ -74,7 +74,7 @@ def validate_label_column(
         raise InvalidDatasetError(
             (
                 f"Invalid label column: {label_column}. "
-                f"{task_type.capitalize()} projects require a label column of type {', '.join(valid_types)}. "
+                f"{str(task_type).capitalize()} projects require a label column of type {', '.join(valid_types)}. "
                 "Also ensure that the column has at least 2 unique values."
             )
         )

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -213,10 +213,14 @@ class Studio:
         dataset_details = api.get_dataset_details(self._api_key, dataset_id, task_type)
 
         if label_column is not None:
-            if label_column not in dataset_details["label_columns"]:
-                raise InvalidDatasetError(
-                    f"Invalid label column: {label_column}. Label column must have categorical feature type"
-                )
+            clean_helpers.validate_label_column(
+                api_key=self._api_key,
+                dataset_id=dataset_id,
+                label_column=label_column,
+                modality=modality,
+                task_type=task_type,
+                possible_label_columns=dataset_details["label_columns"],
+            )
         elif task_type is not None and task_type != "unsupervised":
             label_column = str(dataset_details["label_column_guess"])
             print(f"Label column not supplied. Using best guess {label_column}")
@@ -241,6 +245,7 @@ class Studio:
                 raise InvalidDatasetError(
                     f"Invalid text column: {text_column}. Column must have text feature type"
                 )
+
         if text_column is None and modality == "text":
             text_column = dataset_details["text_column_guess"]
             print(f"Text column not supplied. Using best guess {text_column}")


### PR DESCRIPTION
### Description

This PR contains a few updates to label column validation when creating projects through the Python API:
- Improved error message if label column does not have valid type. Type validation is done in backend in dataset details endpoint.
- Adds column diversity validation for multi-class projects
- Adds validation for multi-label label columns

More context in [notion](https://www.notion.so/cleanlab/Label-column-validation-0fe0f7897f9340288859bcf3f65e6cca?pvs=4)

Note: must be merged after [backend changes](https://github.com/cleanlab/cleanlab-studio-backend/pull/1373)

### How to test

Test w/ [backend changes](https://github.com/cleanlab/cleanlab-studio-backend/pull/1373)
- Attempt to create multi-class tabular project w/ label column containing < 2 classes w/ >= 5 examples each. This should fail.
- Attempt to create multi-class image/text project w/ label column containing < 2 classes w/ >= 5 examples each. This should succeed since it falls under the data labeling workflow
- Attempt to create multi-label project w/ label column that does not contain any comma separated string values. This should fail.
- Verify that error messages for the above are reasonably informative.
