### PR TITLE
Fix variables showing up in docs as globals

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -436,6 +436,9 @@ class Studio:
 
 
 # decorate all functions of self
-for name, method in Studio.__dict__.items():
-    if isinstance(method, FunctionType):
-        setattr(Studio, name, (telemetry(track_all_frames=False))(method))
+#
+# using variable names prepended with "_" to not create global variables that
+# show up in the docs
+for _name, _method in Studio.__dict__.items():
+    if isinstance(_method, FunctionType):
+        setattr(Studio, _name, (telemetry(track_all_frames=False))(_method))


### PR DESCRIPTION
This patch fixes "name" and "method" showing up in the list of global variables defined by this module (which was being rendered in the docs).

There are some other preexisting problems with the telemetry, including missing telemetry for the Model and TLM classes; this patch does not address those issues.

Before:
![Screenshot 2024-04-02 at 7 37 54 PM](https://github.com/cleanlab/cleanlab-studio/assets/3526486/9cb65b94-0349-4492-ac1f-ea7b794a28cd)

After:
![Screenshot 2024-04-02 at 7 37 50 PM](https://github.com/cleanlab/cleanlab-studio/assets/3526486/dcd93526-b640-49b0-ba7a-3ecfb2e8b232)

