### PR TITLE
fix dataframe index when downloading cleanlab columns

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -266,7 +266,7 @@ def download_cleanlab_columns(
     cleanset_json_io = io.StringIO(cleanset_json)
     cleanset_pd: pd.DataFrame = pd.read_json(cleanset_json_io, orient="table")
     cleanset_pd.rename(columns={"id": id_col}, inplace=True)
-    cleanset_pd.sort_values(by=id_col, inplace=True)
+    cleanset_pd.sort_values(by=id_col, inplace=True, ignore_index=True)
     return cleanset_pd
 
 

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -138,11 +138,6 @@ class Studio:
             include_project_details=include_project_details,
             to_spark=to_spark,
         )
-        if "cleanlab_row_ID" in rows_df.columns:
-            if to_spark:
-                rows_df.sort("cleanlab_row_ID")
-            else:
-                rows_df.sort_values(by="cleanlab_row_ID")
         return rows_df
 
     def apply_corrections(self, cleanset_id: str, dataset: Any, keep_excluded: bool = False) -> Any:

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
### Description
This PR fixes an issue that could occur when merging cleanlab columns with the original dataset. After sorting cleanlab columns by id column, it was possible for the index of the dataframe to no longer be in sorted order. Adding the [`ignore_index` parameter](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.sort_values.html) when sorting the dataframe ensures that the resulting dataframe's index column is of the form 0, 1, ... n-1 so that we can merge with the original dataset using `df.merge(cleanlab_columns, left_index=True, right_index=True)` properly.

### How to test
- Tabular quickstart tutorial is an example of a tutorial where merging results was broken before this change. Can run this tutorial and check that results are the same as in the Web UI.