### PR TITLE
add reminder about backend considerations when version bumping

### DIFF
--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,4 +1,4 @@
-# Note to developers: 
+# Note to developers:
 # Consider if backend's min client version needs updating when pushing any changes to this file.
 
 __version__ = "2.0.1"

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,6 +1,5 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
-# https://github.com/cleanlab/cleanlab-studio-backend/blob/staging/backend/api/cli/cli_api.py#L34
 
 __version__ = "2.0.1"
 

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,5 +1,6 @@
 # Note to developers:
-# Consider if backend's min client version needs updating when pushing any changes to this file.
+# Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
+# https://github.com/cleanlab/cleanlab-studio-backend/blob/staging/backend/api/cli/cli_api.py#L34
 
 __version__ = "2.0.1"
 

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,3 +1,6 @@
+# Note to developers: 
+# Consider if backend's min client version needs updating when pushing any changes to this file.
+
 __version__ = "2.0.1"
 
 SCHEMA_VERSION = "0.2.0"


### PR DESCRIPTION
to ensure developers don't forget to update the backend min client version. Sometimes users on old client versions may get opaque errors, if the backend didn't give them a clear alert that they need to upgrade their client