### PR TITLE
Updated download_array to properly read from literal string using StringIO wrapper

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -309,7 +309,7 @@ def download_array(
         if res_json["array_type"] == "numpy":
             np_data: npt.NDArray[np.float_] = np.array(res_json[name])
             return np_data
-        pd_data: pd.DataFrame = pd.read_json(StringIO(res_json[name]), orient='records')
+        pd_data: pd.DataFrame = pd.read_json(StringIO(res_json[name]), orient="records")
         return pd_data
     raise APIError(f"{name} for cleanset {cleanset_id} not found")
 

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 import pandas as pd
 import numpy as np
 import numpy.typing as npt
+from io import StringIO
 
 try:
     import snowflake
@@ -308,7 +309,7 @@ def download_array(
         if res_json["array_type"] == "numpy":
             np_data: npt.NDArray[np.float_] = np.array(res_json[name])
             return np_data
-        pd_data: pd.DataFrame = pd.read_json(res_json[name], orient="records")
+        pd_data: pd.DataFrame = pd.read_json(StringIO(res_json[name]), orient='records')
         return pd_data
     raise APIError(f"{name} for cleanset {cleanset_id} not found")
 


### PR DESCRIPTION
This line below is causing deprecation warnings to appear wherever this line is used, namely in the cleanlab studio [multiannotator tutorial](https://help.cleanlab.ai/tutorials/multiannotator/).

`pd_data: pd.DataFrame = pd.read_json(res_json[name], orient='records')`

The following line in the multiannotator tutorial is what is returning the deprecation warning:

`pred_probs = studio.download_pred_probs(cleanset_id)`

The warning can be seen below:
<img width="1063" alt="Screenshot 2024-04-19 at 11 37 09 AM" src="https://github.com/cleanlab/cleanlab-studio/assets/8604219/a22338f6-3103-42a4-b4a6-a779aadcc40e">
