### PR TITLE
add backticks around regex examples in docstrings

### DIFF
--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -123,7 +123,7 @@ def get_regex_matches(
     Use this function for: tuning regex patterns to extract the best outputs from the raw LLM responses for your dataset obtained via ``enrich_data()``, without having to re-run the LLM.
     If a list of regular expressions is provided, the expressions are applied in order, and the first valid regex match is returned.
 
-    **Note:** Regex patterns should each specify exactly 1 group that is represents the desired characters to be extracted from the raw response using parenthesis like so '(<desired match group pattern>)'.
+    **Note:** Regex patterns should each specify exactly 1 group that is represents the desired characters to be extracted from the raw response using parenthesis like so ``'(<desired match group pattern>)'``.
     **Example 1:** `r'.*The answer is: (Bird|[Rr]abbit).*'` will extract strings that are the words 'Bird', 'Rabbit' or 'rabbit' after the characters "The answer is: " from the raw response text.
     **Example 2:** `r'.*(\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b).*'` will match an email in the raw response LLM response.
 

--- a/cleanlab_studio/utils/data_enrichment/enrichment_utils.py
+++ b/cleanlab_studio/utils/data_enrichment/enrichment_utils.py
@@ -57,7 +57,7 @@ def get_regex_match(
     response: str, regex_list: List[re.Pattern[str]], disable_warnings: bool
 ) -> Union[str, None]:
     """Extract the first match from the response using the provided regex patterns. Return first match if multiple exist.
-    Note: This function assumes the regex patterns each specify exactly 1 group that is the match group using '(<group>)'."""
+    Note: This function assumes the regex patterns each specify exactly 1 group that is the match group using `'(<group>)'`."""
     for regex_pattern in regex_list:
         pattern_match = regex_pattern.match(response)
         if pattern_match:

--- a/cleanlab_studio/utils/data_enrichment/enrichment_utils.py
+++ b/cleanlab_studio/utils/data_enrichment/enrichment_utils.py
@@ -57,7 +57,7 @@ def get_regex_match(
     response: str, regex_list: List[re.Pattern[str]], disable_warnings: bool
 ) -> Union[str, None]:
     """Extract the first match from the response using the provided regex patterns. Return first match if multiple exist.
-    Note: This function assumes the regex patterns each specify exactly 1 group that is the match group using `'(<group>)'`."""
+    Note: This function assumes the regex patterns each specify exactly 1 group that is the match group using ``'(<group>)'``."""
     for regex_pattern in regex_list:
         pattern_match = regex_pattern.match(response)
         if pattern_match:


### PR DESCRIPTION
### Description
The build for help.cleanlab.ai is [currently broken](https://github.com/cleanlab/cleanlab-studio-docs/actions/runs/8913117520/job/24485792921) since there are some places in the docstrings for the data enrichment utils that contain unescaped angled brackets (<>). Since docusaurus converts pages to HTML, these are interpreted as unclosed JSX tags. Adding backticks around these fixes the build issue (and also makes the formatting for these regex examples nicer imo).

### How to test
- Checkout this branch of `cleanlab-studio`
- Run `pip install -Ue .`
- Inside of `cleanlab-studio-docs`, run `make update-notebooks && make update-api-reference && make docs`. Check that building docs succeeds. Navigate to `localhost:3000` and check that API reference docs for data enrichment utils look correct.