### PR TITLE
Feature: add delete method to dataset API

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -461,6 +461,12 @@ def get_cleanset_status(api_key: str, cleanset_id: str) -> JSONDict:
     return status
 
 
+def delete_dataset(api_key: str, dataset_id: str) -> None:
+    check_uuid_well_formed(dataset_id, "dataset ID")
+    res = requests.delete(dataset_base_url + f"/{dataset_id}", headers=_construct_headers(api_key))
+    handle_api_error(res)
+
+
 def delete_project(api_key: str, project_id: str) -> None:
     check_uuid_well_formed(project_id, "project ID")
     res = requests.delete(project_base_url + f"/{project_id}", headers=_construct_headers(api_key))

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -113,6 +113,19 @@ class Studio:
             schema_overrides=schema_overrides,
         )
 
+    def delete_dataset(
+        self,
+        dataset_id: str,
+    ) -> None:
+        """Deletes a dataset from Cleanlab Studio.
+
+        If the dataset is used in projects, the projects will be deleted as well.
+        """
+        api.delete_dataset(
+            self._api_key,
+            dataset_id,
+        )
+
     def download_cleanlab_columns(
         self,
         cleanset_id: str,

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
Add `Studio.delete_dataset` method to API

Backend endpoint is live in `dev` and `staging`

Backend PR: https://github.com/cleanlab/cleanlab-studio-backend/pull/1523