### PR TITLE
Improve data enrichment functions

### DIFF
--- a/cleanlab_studio/internal/enrichment_utils.py
+++ b/cleanlab_studio/internal/enrichment_utils.py
@@ -9,7 +9,7 @@ from cleanlab_studio.errors import ValidationError
 from cleanlab_studio.studio.studio import Studio
 from cleanlab_studio.studio.trustworthy_language_model import TLMResponse
 
-Replacement = Tuple[Union[str, re.Pattern[str]], str]
+Replacement = Tuple[str, str]
 
 
 def get_prompt_outputs(
@@ -43,16 +43,6 @@ def extract_df_subset(
     return subset_df
 
 
-def get_compiled_regex(regex: Union[str, re.Pattern[str]]) -> re.Pattern[str]:
-    """Compile the regex pattern(s) provided and return the compiled regex pattern."""
-    if isinstance(regex, str):
-        return re.compile(rf"{regex}")
-    elif isinstance(regex, re.Pattern):
-        return regex
-    else:
-        raise ValidationError("Passed in regex can only be type one of: str, re.Pattern.")
-
-
 def get_regex_replacement(
     response: str, replacements: Union[Replacement, List[Replacement]]
 ) -> Optional[str]:
@@ -67,10 +57,11 @@ def get_regex_replacement(
     for replacement_pair in replacements_list:
         if not isinstance(replacement_pair, tuple) or len(replacement_pair) != 2:
             raise ValidationError(
-                "Every item of the regex list must be a tuple that contains 2 items. TODO"
+                "Every item of the regex list must be a tuple that contains 2 strings: "
+                "(the regex pattern to match, the string to replace the matched pattern with)"
             )
 
-        compiled_pattern = get_compiled_regex(replacement_pair[0])
+        compiled_pattern = re.compile(replacement_pair[0])
         replacement = replacement_pair[1]
         response = compiled_pattern.sub(replacement, response)
 

--- a/cleanlab_studio/internal/enrichment_utils.py
+++ b/cleanlab_studio/internal/enrichment_utils.py
@@ -54,17 +54,17 @@ def get_compiled_regex(regex: Union[str, re.Pattern[str]]) -> re.Pattern[str]:
 
 
 def get_regex_replacement(
-    response: str, regex_replacements: Union[Replacement, List[Replacement]]
+    response: str, replacements: Union[Replacement, List[Replacement]]
 ) -> Optional[str]:
     """Performs regex replacements to the given string according to the given matching patterns and replacement strings."""
-    if isinstance(regex_replacements, tuple):
-        regex_replacements_list = [regex_replacements]
-    elif isinstance(regex_replacements, list):
-        regex_replacements_list = regex_replacements
+    if isinstance(replacements, tuple):
+        replacements_list = [replacements]
+    elif isinstance(replacements, list):
+        replacements_list = replacements
     else:
         raise ValidationError("Passed in regex has to be either a tuple or a list of tuples.")
 
-    for replacement_pair in regex_replacements_list:
+    for replacement_pair in replacements_list:
         if not isinstance(replacement_pair, tuple) or len(replacement_pair) != 2:
             raise ValidationError(
                 "Every item of the regex list must be a tuple that contains 2 items. TODO"
@@ -77,52 +77,55 @@ def get_regex_replacement(
     return response
 
 
-def get_optimized_prompt(prompt: str, return_values: Optional[List[str]] = None) -> str:
+def get_optimized_prompt(prompt: str, constrain_outputs: Optional[List[str]] = None) -> str:
     """Optimize the prompt by ammending original.
-    Adds a pre-prompt message if return_values are provided. This will help the LLM understand it's response must exactly match one of the return values.
+    Adds a pre-prompt message if constrain_outputs are provided. This will help the LLM understand it's response must exactly match one of the return values.
     """
 
-    if return_values is not None:
-        string_return_values = str(return_values).replace("'", "")
-        pre_prompt = f"Your answer must exactly match one of the following values: [{string_return_values}].\n"
+    if constrain_outputs is not None:
+        string_constrain_outputs = str(constrain_outputs).replace("'", "")
+        pre_prompt = f"Your answer must exactly match one of the following values: [{string_constrain_outputs}].\n"
         optimal_prompt = f"{pre_prompt}{prompt}"
     else:
         optimal_prompt = prompt
     return optimal_prompt
 
 
-def get_return_values_match(
+def get_constrain_outputs_match(
     response: str,
-    return_values: List[str],
-    return_values_pattern: Optional[str] = None,
+    constrain_outputs: List[str],
+    constrain_outputs_pattern: Optional[str] = None,
     disable_warnings: bool = True,
 ) -> str:
-    """Extracts the provided return values from the response using regex patterns. Return first extracted value if multiple exist. If no value out of the possible `return_values` is directly mentioned in the response, the return value with greatest string similarity to the response is returned (along with a warning).
+    """Extracts the provided output values from the response using regex patterns. Return first extracted value if multiple exist.
+    If no value out of the possible `constrain_outputs` is directly mentioned in the response, the return value with greatest string similarity to the response is returned (along with a warning).
 
     Params
     ------
     response: Response from the LLM
-    return_values: List of expected return values
-    return_values_pattern: Pre-compiled pattern of all return values. If not specified, pattern is created.
+    constrain_outputs: List of expected output values
+    constrain_outputs_pattern: Pre-compiled pattern of all output values. If not specified, pattern is created.
     disable_warnings: If True, print warnings are disabled
     """
 
     response_str = str(response)
 
-    if return_values_pattern is None:
-        return_values_pattern = r"(" + "|".join(return_values) + ")"
+    if constrain_outputs_pattern is None:
+        constrain_outputs_pattern = r"(" + "|".join(constrain_outputs) + ")"
 
     # Parse category if LLM response is properly formatted
-    exact_matches = re.findall(return_values_pattern, response_str, re.IGNORECASE)
+    exact_matches = re.findall(constrain_outputs_pattern, response_str, re.IGNORECASE)
     if len(exact_matches) > 0:
         return str(exact_matches[0])
 
     # If there are no exact matches to a specific category, return the closest category based on string similarity.
-    closest_match = max(return_values, key=lambda x: SequenceMatcher(None, response_str, x).ratio())
+    closest_match = max(
+        constrain_outputs, key=lambda x: SequenceMatcher(None, response_str, x).ratio()
+    )
     similarity_score = SequenceMatcher(None, response_str, closest_match).ratio()
     str_warning = "match"
     if similarity_score < 0.5:
         str_warning = "remotely match"
     if not disable_warnings:
-        warnings.warn(f"None of the return_values {str_warning} raw LLM output: {response_str}")
+        warnings.warn(f"None of the constrain_outputs {str_warning} raw LLM output: {response_str}")
     return closest_match

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -40,7 +40,7 @@ def enrich_data(
 
             If a string value is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, None will be returned).
             Specifically the provided string will be passed into Python's `re.match()` method.
-            Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction. 
+            Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction.
             `R1` should be a string containing the regex pattern to match, and `R2` should be a string to replace matches with.
             Pass in a list of tuples instead if you wish to apply multiple replacements. Replacements will be applied in the order they appear in the list.
             Note that you cannot pass in a list of strings (chaining of multiple regex processing steps is only allowed for replacement operations).
@@ -131,7 +131,7 @@ def process_regex(
 
     If a string value is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, None will be returned).
     Specifically the provided string will be passed into Python's `re.match()` method.
-    Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction. 
+    Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction.
     `R1` should be a string containing the regex pattern to match, and `R2` should be a string to replace matches with.
     Pass in a list of tuples instead if you wish to apply multiple replacements. Replacements will be applied in the order they appear in the list.
     Note that you cannot pass in a list of strings (chaining of multiple regex processing steps is only allowed for replacement operations).

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -5,7 +5,7 @@ from cleanlab_studio.internal.enrichment_utils import (
     extract_df_subset,
     get_prompt_outputs,
     get_regex_replacement,
-    get_return_values_match,
+    get_constrain_outputs_match,
     get_optimized_prompt,
     Replacement,
 )
@@ -18,11 +18,11 @@ def enrich_data(
     prompt: str,
     data: pd.DataFrame,
     *,
-    regex_replacements: Optional[Union[Replacement, List[Replacement]]] = None,
-    return_values: Optional[List[str]] = None,
+    replacements: Optional[Union[Replacement, List[Replacement]]] = None,
+    constrain_outputs: Optional[List[str]] = None,
     optimize_prompt: bool = True,
     subset_indices: Optional[Union[Tuple[int, int], List[int]]] = (0, 3),
-    metadata_column_name: str = "metadata",
+    new_column_name: str = "metadata",
     disable_warnings: bool = False,
     **kwargs: Any,
 ) -> pd.DataFrame:
@@ -36,7 +36,7 @@ def enrich_data(
         studio: Cleanlab Studio client object, which you must instantiate before calling this method.
         prompt: Formatted f-string, that contains both the prompt, and names of columns to embed.
             **Example:** "Is this a numeric value, answer Yes or No only. Value: {column_name}"
-        regex_replacements: A tuple or list of tuples each containing a pair of items:
+        replacements: A tuple or list of tuples each containing a pair of items:
             - a regex pattern to match (str or re.Pattern)
             - a string to replace the matched pattern with (str)
             These tuples specify the desired patterns to match and replace from the raw LLM response,
@@ -44,26 +44,26 @@ def enrich_data(
             but can easily transform the raw LLM outputs to be valid through regular expressions that extract and replace parts of the raw output string.
             If a list of tuples is passed in, the replacements are applied in the order they appear in the list.
 
-            **Example 1:** ``regex_replacements = (r'\b(?!(True|False)\b)\w+\b', '')`` will replace all words not True or False with an empty string.
-            **Example 2:** ``regex_replacements = (re.compile(r' Explanation:.*' re.IGNORECASE), '') will remove everything after and including the words "Explanation:".
+            **Example 1:** ``replacements = (r'\b(?!(True|False)\b)\w+\b', '')`` will replace all words not True or False with an empty string.
+            **Example 2:** ``replacements = (re.compile(r' Explanation:.*' re.IGNORECASE), '') will remove everything after and including the words "Explanation:".
             For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True" after the regex replacement.
-        return_values: List of all possible values for the `metadata` column.
+        constrain_outputs: List of all possible values for the `metadata` column.
             If specified, every entry in the `metadata` column will exactly match one of these values (for less open-ended data enrichment tasks). If None, the `metadata` column can contain arbitrary values (for more open-ended data enrichment tasks).
             After your regex is applied, there may be additional transformations applied to ensure the returned value is one of these.
-            If `optimize_prompt` is True, the prompt will be automatically adjusted to include a statement that the response must match one of the `return_values`.
+            If `optimize_prompt` is True, the prompt will be automatically adjusted to include a statement that the response must match one of the `constrain_outputs`.
         optimize_prompt: When False, your provided prompt will not be modified in any way. When True, your provided prompt may be automatically adjusted in an effort to produce better results.
-            For instance, if the return_values are constrained, we may automatically append the following statement to your prompt: "Your answer must exactly match one of the following values: `return_values`."
+            For instance, if the constrain_outputs are constrained, we may automatically append the following statement to your prompt: "Your answer must exactly match one of the following values: `constrain_outputs`."
         subset_indices: What subset of the supplied data rows to generate metadata for. If None, we run on all of the data.
             This can be either a list of unique indices or a range. These indices are passed into pandas ``.iloc`` method, so should be integers based on row order as opposed to row-index labels pointing to `df.index`.
             We advise against collecting results for all of your data at first. First collect results for a smaller data subset, and use this subset to experiment with different values of the `prompt` or `regex` arguments. Only once the results look good for your subset should you run on the full dataset.
-        metadata_column_name: Optional name for the returned metadata column. Name acts as a prefix appended to all additional columns that are returned.
+        new_column_name: Optional name for the returned metadata column. Name acts as a prefix appended to all additional columns that are returned.
         disable_warnings: When True, warnings are disabled.
 
     Returns:
-        A DataFrame that contains `metadata` and `trustworthiness` columns related to the prompt in order of original data. Some columns names will have `metadata_column_name` prepended to them.
-        `metadata` column = responses to the prompt and other data mutations if `regex` or `return_values` is not specified.
+        A DataFrame that contains `metadata` and `trustworthiness` columns related to the prompt in order of original data. Some columns names will have `new_column_name` prepended to them.
+        `metadata` column = responses to the prompt and other data mutations if `replacements` or `constrain_outputs` is not specified.
         `trustworthiness` column = trustworthiness of the prompt responses (which ignore the data mutations).
-        **Note**: If you specified the `regex` or `return_values` arguments, some additional transformations may be applied to raw LLM outputs to produce the returned values. In these cases, an additional `log` column will be added to the returned DataFrame that records the raw LLM outputs (feel free to disregard these).
+        **Note**: If you specified the `replacements` or `constrain_outputs` arguments, some additional transformations may be applied to raw LLM outputs to produce the returned values. In these cases, an additional `log` column will be added to the returned DataFrame that records the raw LLM outputs (feel free to disregard these).
     """
     if subset_indices:
         df = extract_df_subset(data, subset_indices)
@@ -71,43 +71,43 @@ def enrich_data(
         df = data.copy()
 
     if optimize_prompt:
-        prompt = get_optimized_prompt(prompt, return_values)
+        prompt = get_optimized_prompt(prompt, constrain_outputs)
 
     outputs = get_prompt_outputs(studio, prompt, df, **kwargs)
-    column_name_prefix = metadata_column_name + "_"
+    column_name_prefix = new_column_name + "_"
 
     df[f"{column_name_prefix}trustworthiness"] = [
         output["trustworthiness_score"] if output is not None else None for output in outputs
     ]
-    df[f"{metadata_column_name}"] = [
+    df[f"{new_column_name}"] = [
         output["response"] if output is not None else None for output in outputs
     ]
 
     if (
-        regex_replacements is None and return_values is None
+        replacements is None and constrain_outputs is None
     ):  # we do not need to have a "log" column as original output is not augmented by regex or return values
-        return df[[f"{metadata_column_name}", f"{column_name_prefix}trustworthiness"]]
+        return df[[f"{new_column_name}", f"{column_name_prefix}trustworthiness"]]
 
     df[f"{column_name_prefix}log"] = [
         output["response"] if output is not None else None for output in outputs
     ]
 
-    if regex_replacements:
-        df[f"{metadata_column_name}"] = df[f"{metadata_column_name}"].apply(
-            lambda x: get_regex_replacement(x, regex_replacements)
+    if replacements:
+        df[f"{new_column_name}"] = df[f"{new_column_name}"].apply(
+            lambda x: get_regex_replacement(x, replacements)
         )
 
-    if return_values:
-        return_values_pattern = r"(" + "|".join(return_values) + ")"
-        df[f"{metadata_column_name}"] = df[f"{metadata_column_name}"].apply(
-            lambda x: get_return_values_match(
-                x, return_values, return_values_pattern, disable_warnings
+    if constrain_outputs:
+        constrain_outputs_pattern = r"(" + "|".join(constrain_outputs) + ")"
+        df[f"{new_column_name}"] = df[f"{new_column_name}"].apply(
+            lambda x: get_constrain_outputs_match(
+                x, constrain_outputs, constrain_outputs_pattern, disable_warnings
             )
         )
 
     return df[
         [
-            f"{metadata_column_name}",
+            f"{new_column_name}",
             f"{column_name_prefix}trustworthiness",
             f"{column_name_prefix}log",
         ]
@@ -116,7 +116,7 @@ def enrich_data(
 
 def get_regex_replacements(
     column_data: Union[pd.Series, List[str]],
-    regex_replacements: Union[Replacement, List[Replacement]],
+    replacements: Union[Replacement, List[Replacement]],
 ) -> Union[pd.Series, List[str]]:
     """
     Performs regex replacements to the given string according to the given matching patterns and replacement strings.
@@ -124,13 +124,13 @@ def get_regex_replacements(
     Use this function for: tuning regex replacements to obtain the best outputs from the raw LLM responses for your dataset obtained via ``enrich_data()``, without having to re-run the LLM.
     If a list of tuples is passed in, the replacements are applied in the order they appear in the list.
 
-    **Example 1:** ``regex_replacements = (r'\b(?!(True|False)\b)\w+\b', '')`` will replace all words not True or False with an empty string.
-    **Example 2:** ``regex_replacements = (re.compile(r' Explanation:.*' re.IGNORECASE), '') will remove everything after and including the words "Explanation:".
+    **Example 1:** ``replacements = (r'\b(?!(True|False)\b)\w+\b', '')`` will replace all words not True or False with an empty string.
+    **Example 2:** ``replacements = (re.compile(r' Explanation:.*' re.IGNORECASE), '') will remove everything after and including the words "Explanation:".
     For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True" after the regex replacement.
 
     Args:
         column_data: A pandas Series or list of strings, where you want to apply a regex to extract matches from each element. This could be the `metadata` column output by ``enrich_data()``.
-        regex_replacements: A tuple or list of tuples each containing a pair of items:
+        replacements: A tuple or list of tuples each containing a pair of items:
             - a regex pattern to match (str or re.Pattern)
             - a string to replace the matched pattern with (str)
 
@@ -138,8 +138,8 @@ def get_regex_replacements(
         Extracted matches to the provided regular expression from each element of the data column (specifically, the first match is returned).
     """
     if isinstance(column_data, list):
-        return [get_regex_replacement(x, regex_replacements) for x in column_data]
+        return [get_regex_replacement(x, replacements) for x in column_data]
     elif isinstance(column_data, pd.Series):
-        return column_data.apply(lambda x: get_regex_replacement(x, regex_replacements))
+        return column_data.apply(lambda x: get_regex_replacement(x, replacements))
     else:
         raise TypeError("column_data should be a pandas Series or a list of strings.")

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -122,7 +122,7 @@ def enrich_data(
 
 def process_regex(
     column_data: Union[pd.Series, List[str]],
-    regex: Optional[Union[str, Replacement, List[Replacement]]] = None,
+    regex: Union[str, Replacement, List[Replacement]],
 ) -> Union[pd.Series, List[str]]:
     """
     Performs regex matches or replacements to the given string according to the given matching patterns and replacement strings.

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -48,6 +48,8 @@ def enrich_data(
             These tuples specify the desired patterns to match and replace from the raw LLM response,
             This regex processing is useful in settings where you are unable to prompt the LLM to generate valid outputs 100% of the time,
             but can easily transform the raw LLM outputs to be valid through regular expressions that extract and replace parts of the raw output string.
+            When this regex is applied, the processed results can be seen ithe ``{new_column_name}`` column, and the raw outpus (before any regex processing)
+            will be saved in the ``{new_column_name}_log`` column of the results dataframe.
 
             **Example 1:** ``regex = '.*The answer is: (Bird|[Rr]abbit).*'`` will extract strings that are the words 'Bird', 'Rabbit' or 'rabbit' after the characters "The answer is: " from the raw response.
             **Example 2:** ``regex = [('True', 'T'), ('False', 'F')]`` will replace the words True and False with T and F.
@@ -67,9 +69,9 @@ def enrich_data(
 
     Returns:
         A DataFrame that contains `metadata` and `trustworthiness` columns related to the prompt in order of original data. Some columns names will have `new_column_name` prepended to them.
-        `metadata` column = responses to the prompt and other data mutations if `replacements` or `constrain_outputs` is not specified.
+        `metadata` column = responses to the prompt and other data mutations if `regex` or `constrain_outputs` is not specified.
         `trustworthiness` column = trustworthiness of the prompt responses (which ignore the data mutations).
-        **Note**: If you specified the `replacements` or `constrain_outputs` arguments, some additional transformations may be applied to raw LLM outputs to produce the returned values. In these cases, an additional `log` column will be added to the returned DataFrame that records the raw LLM outputs (feel free to disregard these).
+        **Note**: If you specified the `regex` or `constrain_outputs` arguments, some additional transformations may be applied to raw LLM outputs to produce the returned values. In these cases, an additional `log` column will be added to the returned DataFrame that records the raw LLM outputs (feel free to disregard these).
     """
     if subset_indices:
         df = extract_df_subset(data, subset_indices)

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -142,4 +142,4 @@ def get_regex_replacements(
     elif isinstance(column_data, pd.Series):
         return column_data.apply(lambda x: get_regex_replacement(x, replacements))
     else:
-        raise TypeError("column_data should be a pandas Series or a list of strings.")|
+        raise TypeError("column_data should be a pandas Series or a list of strings.")

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -54,7 +54,7 @@ def enrich_data(
             **Example 1:** ``regex = '.*The answer is: (Bird|[Rr]abbit).*'`` will extract strings that are the words 'Bird', 'Rabbit' or 'rabbit' after the characters "The answer is: " from the raw response.
             **Example 2:** ``regex = [('True', 'T'), ('False', 'F')]`` will replace the words True and False with T and F.
             **Example 3:** ``regex = (' Explanation:.*', '') will remove everything after and including the words "Explanation:".
-            For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True" after the regex replacement.
+            For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True." after the regex replacement.
         constrain_outputs (List[str], optional): List of all possible output values for the `metadata` column.
             If specified, every entry in the `metadata` column will exactly match one of these values (for less open-ended data enrichment tasks). If None, the `metadata` column can contain arbitrary values (for more open-ended data enrichment tasks).
            There may be additional transformations applied to ensure the returned value is one of these. If regex is also specified, then these transformations occur after your regex is applied.
@@ -141,7 +141,7 @@ def process_regex(
     **Example 1:** ``regex = '.*The answer is: (Bird|[Rr]abbit).*'`` will extract strings that are the words 'Bird', 'Rabbit' or 'rabbit' after the characters "The answer is: " from the raw response.
     **Example 2:** ``regex = [('True', 'T'), ('False', 'F')]`` will replace the words True and False with T and F.
     **Example 3:** ``regex = (' Explanation:.*', '') will remove everything after and including the words "Explanation:".
-    For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True" after the regex replacement.
+    For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True." after the regex replacement.
 
     Args:
         column_data (pd.Series | List[str]): A pandas Series or list of strings, where you want to apply a regex to extract matches from each element. This could be the `metadata` column output by ``enrich_data()``.

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -56,7 +56,7 @@ def enrich_data(
         subset_indices (Tuple[int, int] | List[int], optional): What subset of the supplied data rows to generate metadata for. If None, we run on all of the data.
             This can be either a list of unique indices or a range. These indices are passed into pandas ``.iloc`` method, so should be integers based on row order as opposed to row-index labels pointing to `df.index`.
             We advise against collecting results for all of your data at first. First collect results for a smaller data subset, and use this subset to experiment with different values of the `prompt` or `regex` arguments. Only once the results look good for your subset should you run on the full dataset.
-        new_column_name (str): Optional name for the returned new metadata column. Name acts as a prefix appended to all additional columns that are returned.
+        new_column_name (str): Optional name for the returned enriched column. Name acts as a prefix appended to all additional columns that are returned.
         disable_warnings (bool, default = False): When True, warnings are disabled.
 
     Returns:

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -36,14 +36,14 @@ def enrich_data(
         data (pd.DataFrame): A pandas DataFrame containing your data.
         prompt (str): Formatted f-string, that contains both the prompt, and names of columns to embed.
             **Example:** "Is this a numeric value, answer Yes or No only. Value: {column_name}"
-        regex (str | Replacement | List[Replacement], optional): A string, a tuple or list of tuples each containing:
-            - a string containing the regex pattern to match
-            - a string to replace the matched pattern with
+        regex (str | Replacement | List[Replacement], optional): A string, tuple, or list of tuples specifying regular expressions to apply for post-processing the raw LLM outputs.
 
-            If a string is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, it will return None).
-            If a tuple is passed in, the function will perform regex replacements on the response according to the given matching patterns and replacement strings.
-            If a list of tuples is passed in, the replacements are applied in the order they appear in the list.
-            Note that you cannot pass in a list of strings (chaining of multiple regex steps is only allowed for replacements).
+            If a string value is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, None will be returned).
+            Specifically the provided string will be passed into Python's `re.match()` method.
+            Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction. 
+            `R1` should be a string containing the regex pattern to match, and `R2` should be a string to replace matches with.
+            Pass in a list of tuples instead if you wish to apply multiple replacements. Replacements will be applied in the order they appear in the list.
+            Note that you cannot pass in a list of strings (chaining of multiple regex processing steps is only allowed for replacement operations).
 
             These tuples specify the desired patterns to match and replace from the raw LLM response,
             This regex processing is useful in settings where you are unable to prompt the LLM to generate valid outputs 100% of the time,

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -129,10 +129,12 @@ def process_regex(
 
     Use this function for: tuning regex replacements to obtain the best outputs from the raw LLM responses for your dataset obtained via ``enrich_data()``, without having to re-run the LLM.
 
-    If a string is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, it will return None).
-    If a tuple is passed in, the function will perform regex replacements on the response according to the given matching patterns and replacement strings.
-    If a list of tuples is passed in, the replacements are applied in the order they appear in the list.
-    Note that you cannot pass in a list of strings (chaining of multiple regex steps is only allowed for replacements).
+    If a string value is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, None will be returned).
+    Specifically the provided string will be passed into Python's `re.match()` method.
+    Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction. 
+    `R1` should be a string containing the regex pattern to match, and `R2` should be a string to replace matches with.
+    Pass in a list of tuples instead if you wish to apply multiple replacements. Replacements will be applied in the order they appear in the list.
+    Note that you cannot pass in a list of strings (chaining of multiple regex processing steps is only allowed for replacement operations).
 
     **Example 1:** ``regex = '.*The answer is: (Bird|[Rr]abbit).*'`` will extract strings that are the words 'Bird', 'Rabbit' or 'rabbit' after the characters "The answer is: " from the raw response.
     **Example 2:** ``regex = [('True', 'T'), ('False', 'F')]`` will replace the words True and False with T and F.
@@ -141,9 +143,7 @@ def process_regex(
 
     Args:
         column_data (pd.Series | List[str]): A pandas Series or list of strings, where you want to apply a regex to extract matches from each element. This could be the `metadata` column output by ``enrich_data()``.
-        regex (str | Replacement | List[Replacement]): A string, a tuple or list of tuples each containing:
-            - a string containing the regex pattern to match
-            - a string to replace the matched pattern with
+        regex (str | Replacement | List[Replacement]): A string, tuple, or list of tuples specifying regular expressions to apply for post-processing the raw LLM outputs.
 
     Returns:
         Extracted matches to the provided regular expression from each element of the data column (specifically, the first match is returned).

--- a/cleanlab_studio/utils/data_enrichment/enrich.py
+++ b/cleanlab_studio/utils/data_enrichment/enrich.py
@@ -57,7 +57,7 @@ def enrich_data(
             For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True" after the regex replacement.
         constrain_outputs (List[str], optional): List of all possible output values for the `metadata` column.
             If specified, every entry in the `metadata` column will exactly match one of these values (for less open-ended data enrichment tasks). If None, the `metadata` column can contain arbitrary values (for more open-ended data enrichment tasks).
-            After your regex is applied, there may be additional transformations applied to ensure the returned value is one of these.
+           There may be additional transformations applied to ensure the returned value is one of these. If regex is also specified, then these transformations occur after your regex is applied.
             If `optimize_prompt` is True, the prompt will be automatically adjusted to include a statement that the response must match one of the `constrain_outputs`.
         optimize_prompt (bool, default = True): When False, your provided prompt will not be modified in any way. When True, your provided prompt may be automatically adjusted in an effort to produce better results.
             For instance, if the constrain_outputs are constrained, we may automatically append the following statement to your prompt: "Your answer must exactly match one of the following values: `constrain_outputs`."

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.0.6"
+__version__ = "2.0.7"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
- change how regex is being used: support both extraction (matching) and replacements
- set default model used as `claude-3-haiku`

blocked by the merge of https://github.com/cleanlab/cleanlab-studio/pull/230 (which allows the use to claude models)

### Sample usage

```python
data = pd.DataFrame({"inputs": ["1, 1, 1", "1, 2, 3", "1, 2, 3.5", "2, 4, 6"]})
prompt = "What is the sum of given numbers? Respond in the format 'The sum is: <sum>'. Numbers: {inputs}"

initial_results = enrich_data(studio, data, prompt, subset_indices=None)
initial_results = data.join(initial_results)

# try a bunch of prompts and regexes using process_regex (replacements)
# example 1: replace all non-numbers
process_regex(initial_results["metadata"], ('\D', '')) 

# example 2: (chaining regex replacements) remove the prefix The sum is:" and also any periods at the end of the sentence
# this sample is better (it does not incorrectly remove decimal points)
process_regex(initial_results["metadata"], [('.*The sum is:', ''), ('\.$', "")])

# example 3: simplify it even more by using matching
process_regex(initial_results["metadata"], ".*The sum is: (.*)")

# so now we can pass the regex directly in the enrich_data function
results = enrich_data(studio, data, prompt, regex=".*The sum is: (.*)", subset_indices=None)
results = data.join(results)
results
```

### Reviewer notes
@eytanhanig if you could verify that the expected use of regex is similar to what was scoped out for the backend API, that'd be great, thanks!