### PR TITLE
Add ability to add, delete, and get enrichment project(s)

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -604,7 +604,6 @@ def delete_enrichment_project(api_key: str, project_id: str) -> None:
         f"{enrichment_base_url}/projects/{project_id}", headers=_construct_headers(api_key)
     )
     handle_api_error(res)
-    return
 
 
 def get_enrichment_project(api_key: str, project_id: str) -> JSONDict:
@@ -618,7 +617,7 @@ def get_enrichment_project(api_key: str, project_id: str) -> JSONDict:
     return cast(JSONDict, res.json())
 
 
-def get_enrichment_projects(api_key: str) -> List[JSONDict]:
+def list_all_enrichment_projects(api_key: str) -> List[JSONDict]:
     """Get a list of all enrichment projects."""
     all_projects: List[JSONDict] = []
     page: Optional[int] = 1

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -594,8 +594,7 @@ def create_enrichment_project(
         json=request_json,
     )
     handle_api_error(res)
-    res_json: JSONDict = res.json()
-    return cast(JSONDict, res_json)
+    return cast(JSONDict, res.json())
 
 
 def delete_enrichment_project(api_key: str, project_id: str) -> None:
@@ -616,8 +615,7 @@ def get_enrichment_project(api_key: str, project_id: str) -> JSONDict:
         headers=_construct_headers(api_key),
     )
     handle_api_error(res)
-    res_json: JSONDict = res.json()
-    return cast(JSONDict, res_json)
+    return cast(JSONDict, res.json())
 
 
 def get_enrichment_projects(api_key: str) -> List[JSONDict]:

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -579,14 +579,12 @@ def create_enrichment_project(
     api_key: str,
     dataset_id: str,
     name: str,
-    target_column_in_dataset: str,
 ) -> JSONDict:
     """Create a new enrichment project."""
     check_uuid_well_formed(dataset_id, "dataset ID")
     request_json = dict(
         dataset_id=dataset_id,
         name=name,
-        target_column_in_dataset=target_column_in_dataset,
     )
     res = requests.post(
         f"{enrichment_base_url}/projects",

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, Literal, Optional, TypedDict, Union
-from datetime import datetime
+from typing import Any, Dict, Optional, TypedDict, Literal
+
 
 JSONDict = Dict[str, Any]
 
@@ -15,11 +15,3 @@ TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
 class CleanlabSettingsDict(TypedDict):
     version: Optional[str]
     api_key: Optional[str]
-
-
-class EnrichmentProjectFromDict(TypedDict):
-    api_key: str
-    id: str
-    name: str
-    target_column_in_dataset: str
-    created_at: Optional[Union[str, datetime]]

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, Optional, TypedDict, Literal
-
+from typing import Any, Dict, Literal, Optional, TypedDict, Union
+from datetime import datetime
 
 JSONDict = Dict[str, Any]
 
@@ -15,3 +15,11 @@ TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
 class CleanlabSettingsDict(TypedDict):
     version: Optional[str]
     api_key: Optional[str]
+
+
+class EnrichmentProjectFromDict(TypedDict):
+    api_key: str
+    id: str
+    name: str
+    target_column_in_dataset: str
+    created_at: Optional[Union[str, datetime]]

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -71,9 +71,8 @@ class EnrichmentProject:
         (datetime.datetime) When the Enrichment Project was created.
         """
         if self._created_at is None:
-            self._created_at = _response_timestamp_to_datetime(
-                self._get_enrichment_project_dict()["created_at"]
-            )
+            create_at_string = self._get_enrichment_project_dict()["created_at"]
+            self._created_at = _response_timestamp_to_datetime(create_at_string)
 
         return self._created_at
 
@@ -96,17 +95,3 @@ class EnrichmentProject:
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
-
-    @staticmethod
-    def from_dict(d: EnrichmentProjectFromDict) -> "EnrichmentProject":
-        """
-        **Objects of this class are not meant to be constructed directly.**
-        Instead, use [`Studio.get_enrichment_project()`](../studio/#method-get_enrichment_project).
-        """
-        return EnrichmentProject(
-            api_key=d.get("api_key"),
-            id=d.get("id"),
-            name=d.get("name"),
-            target_column_in_dataset=d.get("target_column_in_dataset"),
-            created_at=d.get("created_at", None),
-        )

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -40,6 +40,7 @@ class EnrichmentProject:
         self._api_key = api_key
         self._id = id
         self._name = name
+        self._created_at: Optional[datetime]
         if isinstance(created_at, str):
             self._created_at = _response_timestamp_to_datetime(created_at)
         else:

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Union
 
 from cleanlab_studio.internal.api import api
-from cleanlab_studio.internal.types import EnrichmentProjectFromDict
 
 
 def _response_timestamp_to_datetime(timestamp_string: str) -> datetime:

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -40,8 +40,8 @@ class EnrichmentProject:
         self._api_key = api_key
         self._id = id
         self._name = name
-        self._created_at_string = created_at_string
         self.target_column_in_dataset = target_column_in_dataset
+        self._created_at_string = created_at_string
 
     def _get_enrichment_project_dict(self) -> Dict[str, Any]:
         return dict(api.get_enrichment_project(api_key=self._api_key, project_id=self._id))
@@ -65,3 +65,12 @@ class EnrichmentProject:
     def updated_at(self) -> datetime:
         updated_at = self._get_enrichment_project_dict()["updated_at"]
         return _response_timestamp_to_datetime(updated_at)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "target_column_in_dataset": self.target_column_in_dataset,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -30,7 +30,6 @@ class EnrichmentProject:
         api_key: str,
         id: str,
         name: str,
-        target_column_in_dataset: str,
         created_at: Optional[Union[str, datetime]] = None,
     ) -> None:
         """Initialize an EnrichmentProject.
@@ -41,7 +40,6 @@ class EnrichmentProject:
         self._api_key = api_key
         self._id = id
         self._name = name
-        self.target_column_in_dataset = target_column_in_dataset
         if isinstance(created_at, str):
             self._created_at = _response_timestamp_to_datetime(created_at)
         else:
@@ -90,7 +88,6 @@ class EnrichmentProject:
         return {
             "id": self.id,
             "name": self.name,
-            "target_column_in_dataset": self.target_column_in_dataset,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -6,7 +6,7 @@ Methods for interfacing with Enrichment Projects.
 
 from __future__ import annotations
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from cleanlab_studio.internal.api import api
 
@@ -43,7 +43,7 @@ class EnrichmentProject:
         self._created_at_string = created_at_string
         self.target_column_in_dataset = target_column_in_dataset
 
-    def _get_project_dict(self):
+    def _get_enrichment_project_dict(self) -> Dict[str, Any]:
         return dict(api.get_enrichment_project(api_key=self._api_key, project_id=self._id))
 
     @property
@@ -57,11 +57,11 @@ class EnrichmentProject:
     @property
     def created_at(self) -> datetime:
         if self._created_at_string is None:
-            self._created_at_string = self._get_project_dict()["created_at"]
+            self._created_at_string = self._get_enrichment_project_dict()["created_at"]
 
         return _response_timestamp_to_datetime(self._created_at_string)
 
     @property
     def updated_at(self) -> datetime:
-        updated_at = self._get_project_dict()["updated_at"]
+        updated_at = self._get_enrichment_project_dict()["updated_at"]
         return _response_timestamp_to_datetime(updated_at)

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -1,0 +1,67 @@
+"""
+Methods for interfacing with Enrichment Projects.
+
+**This module is not meant to be imported and used directly.** Instead, use [`Studio.get_enrichment_project()`](../studio/#method-get_enrichment_project) to instantiate an [EnrichmentProject](#class-enrichmentproject) object.
+"""
+
+from __future__ import annotations
+from datetime import datetime
+from typing import Optional
+
+from cleanlab_studio.internal.api import api
+
+
+def _response_timestamp_to_datetime(timestamp_string: str) -> datetime:
+    """
+    Converts the timestamp strings returned by the Cleanlab Studio API into datetime typing.
+    """
+    response_timestamp_format_str = "%a, %d %b %Y %H:%M:%S %Z"
+    return datetime.strptime(timestamp_string, response_timestamp_format_str)
+
+
+class EnrichmentProject:
+    """Represents an Enrichment Project instance, which is bound to a Cleanlab Studio account.
+
+    EnrichmentProjects should be instantiated using the [`Studio.get_enrichment_project()`](../studio/#method-get_enrichment_project) method.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        id: str,
+        name: str,
+        target_column_in_dataset: str,
+        created_at_string: Optional[str] = None,
+    ) -> None:
+        """Initialize an EnrichmentProject.
+
+        **Objects of this class are not meant to be constructed directly.** Instead, use [`Studio.get_enrichment_project()`](../studio/#method-get_enrichment_project).
+        """
+        self._api_key = api_key
+        self._id = id
+        self._name = name
+        self._created_at_string = created_at_string
+        self.target_column_in_dataset = target_column_in_dataset
+
+    def _get_project_dict(self):
+        return dict(api.get_enrichment_project(api_key=self._api_key, project_id=self._id))
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def created_at(self) -> datetime:
+        if self._created_at_string is None:
+            self._created_at_string = self._get_project_dict()["created_at"]
+
+        return _response_timestamp_to_datetime(self._created_at_string)
+
+    @property
+    def updated_at(self) -> datetime:
+        updated_at = self._get_project_dict()["updated_at"]
+        return _response_timestamp_to_datetime(updated_at)

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -401,7 +401,6 @@ class Studio:
         self,
         name: str,
         dataset_id: str,
-        target_column_in_dataset: str = "metadata",
     ) -> enrichment.EnrichmentProject:
         """
         Creates a Cleanlab Studio Enrichment Project.
@@ -409,7 +408,6 @@ class Studio:
         Args:
             name (str): Name of the enrichment project to create.
             dataset_id (str): ID of dataset to be enriched.
-            target_column_in_dataset: (str): Name of the column to populate with new data. Defaults to "metadata".
 
         Returns:
             EnrichmentProject: The [EnrichmentProject](../enrichment#class-enrichmentproject) object
@@ -419,14 +417,12 @@ class Studio:
             api_key=self._api_key,
             name=name,
             dataset_id=dataset_id,
-            target_column_in_dataset=target_column_in_dataset,
         )
 
         return enrichment.EnrichmentProject(
             api_key=self._api_key,
             id=enrichment_project_dict["id"],
             name=enrichment_project_dict["name"],
-            target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
             created_at=enrichment_project_dict["created_at"],
         )
 
@@ -463,7 +459,6 @@ class Studio:
             self._api_key,
             id=project_id,
             name=enrichment_project_dict["name"],
-            target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
             created_at=enrichment_project_dict["created_at"],
         )
 
@@ -485,7 +480,6 @@ class Studio:
                 self._api_key,
                 id=enrichment_project_dict["id"],
                 name=enrichment_project_dict["name"],
-                target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
             )
             for enrichment_project_dict in enrichment_project_dicts
         ]

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -480,6 +480,7 @@ class Studio:
                 self._api_key,
                 id=enrichment_project_dict["id"],
                 name=enrichment_project_dict["name"],
+                created_at=enrichment_project_dict["created_at"],
             )
             for enrichment_project_dict in enrichment_project_dicts
         ]

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -399,16 +399,16 @@ class Studio:
 
     def create_enrichment_project(
         self,
-        dataset_id: str,
         name: str,
+        dataset_id: str,
         target_column_in_dataset: str = "metadata",
     ) -> enrichment.EnrichmentProject:
         """
         Creates a Cleanlab Studio Enrichment Project.
 
         Args:
-            dataset_id (str): ID of dataset to be enriched.
             name (str): Name of the enrichment project to create.
+            dataset_id (str): ID of dataset to be enriched.
             target_column_in_dataset: (str): Name of the column to populate with new data. Defaults to "metadata".
 
         Returns:
@@ -417,17 +417,15 @@ class Studio:
         """
         enrichment_project_dict = api.create_enrichment_project(
             api_key=self._api_key,
-            dataset_id=dataset_id,
             name=name,
+            dataset_id=dataset_id,
             target_column_in_dataset=target_column_in_dataset,
         )
-
-        return enrichment.EnrichmentProject(
-            self._api_key,
-            id=enrichment_project_dict["id"],
-            name=enrichment_project_dict["name"],
-            target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
-            created_at_string=enrichment_project_dict["created_at"],
+        return enrichment.EnrichmentProject.from_dict(
+            {
+                "api_key": self._api_key,
+                **enrichment_project_dict,
+            }
         )
 
     def delete_enrichment_project(self, project_id: str) -> None:
@@ -464,7 +462,7 @@ class Studio:
             id=project_id,
             name=enrichment_project_dict["name"],
             target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
-            created_at_string=enrichment_project_dict["created_at"],
+            created_at=enrichment_project_dict["created_at"],
         )
 
     def get_enrichment_projects(

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -476,7 +476,7 @@ class Studio:
         Returns:
             List[EnrichmentProject]: A list of [EnrichmentProject](../enrichment#class-enrichmentproject) objects.
         """
-        enrichment_project_dicts = api.get_enrichment_projects(
+        enrichment_project_dicts = api.list_all_enrichment_projects(
             api_key=self._api_key,
         )
 

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from . import inference
+from . import enrichment
 from . import trustworthy_language_model
 from cleanlab_studio.errors import CleansetError
 from cleanlab_studio.internal import clean_helpers, upload_helpers
@@ -395,6 +396,99 @@ class Studio:
             3. If there are rows flagged as `is_not_analyzed`, the rows of the feature embeddings will correspond to the rows of the original dataset after filtering out the rows that are not analyzed.
         """
         return np.asarray(api.download_array(self._api_key, cleanset_id, "embeddings"))
+
+    def create_enrichment_project(
+        self,
+        dataset_id: str,
+        name: str,
+        target_column_in_dataset: str = "metadata",
+    ) -> enrichment.EnrichmentProject:
+        """
+        Creates a Cleanlab Studio Enrichment Project.
+
+        Args:
+            dataset_id (str): ID of dataset to be enriched.
+            name (str): Name of the enrichment project to create.
+            target_column_in_dataset: (str): Name of the column to populate with new data. Defaults to "metadata".
+
+        Returns:
+            EnrichmentProject: The [EnrichmentProject](../enrichment#class-enrichmentproject) object
+            for the new enrichment project.
+        """
+        enrichment_project_dict = api.create_enrichment_project(
+            api_key=self._api_key,
+            dataset_id=dataset_id,
+            name=name,
+            target_column_in_dataset=target_column_in_dataset,
+        )
+
+        return enrichment.EnrichmentProject(
+            self._api_key,
+            id=enrichment_project_dict["id"],
+            name=enrichment_project_dict["name"],
+            target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
+            created_at_string=enrichment_project_dict["created_at"],
+        )
+
+    def delete_enrichment_project(self, project_id: str) -> None:
+        """
+        Deletes an Enrichment Project from Cleanlab Studio.
+
+        Args:
+            project_id: ID of enrichment project to delete.
+        """
+        api.delete_enrichment_project(self._api_key, project_id=project_id)
+        print(f"Successfully deleted enrichment project: {project_id}")
+
+    def get_enrichment_project(
+        self,
+        project_id: str,
+    ) -> enrichment.EnrichmentProject:
+        """
+        Get an EnrichmentProject objection for a given Cleanlab Studio Enrichment Project's ID.
+
+        Args:
+            project_id (str): ID of the enrichment project.
+
+        Returns:
+            EnrichmentProject: The [EnrichmentProject](../enrichment#class-enrichmentproject) object
+            for the enrichment project.
+        """
+        enrichment_project_dict = api.get_enrichment_project(
+            api_key=self._api_key,
+            project_id=project_id,
+        )
+
+        return enrichment.EnrichmentProject(
+            self._api_key,
+            id=project_id,
+            name=enrichment_project_dict["name"],
+            target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
+            created_at_string=enrichment_project_dict["created_at"],
+        )
+
+    def get_enrichment_projects(
+        self,
+    ) -> list[enrichment.EnrichmentProject]:
+        """
+        Get a list of all EnrichmentProjects.
+
+        Returns:
+            list[EnrichmentProject]: A list of [EnrichmentProject](../enrichment#class-enrichmentproject) objects.
+        """
+        enrichment_project_dicts = api.get_enrichment_projects(
+            api_key=self._api_key,
+        )
+
+        return [
+            enrichment.EnrichmentProject(
+                self._api_key,
+                id=enrichment_project_dict["id"],
+                name=enrichment_project_dict["name"],
+                target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
+            )
+            for enrichment_project_dict in enrichment_project_dicts
+        ]
 
     def TLM(
         self,

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -469,12 +469,12 @@ class Studio:
 
     def get_enrichment_projects(
         self,
-    ) -> list[enrichment.EnrichmentProject]:
+    ) -> List[enrichment.EnrichmentProject]:
         """
         Get a list of all EnrichmentProjects.
 
         Returns:
-            list[EnrichmentProject]: A list of [EnrichmentProject](../enrichment#class-enrichmentproject) objects.
+            List[EnrichmentProject]: A list of [EnrichmentProject](../enrichment#class-enrichmentproject) objects.
         """
         enrichment_project_dicts = api.get_enrichment_projects(
             api_key=self._api_key,

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -421,11 +421,13 @@ class Studio:
             dataset_id=dataset_id,
             target_column_in_dataset=target_column_in_dataset,
         )
-        return enrichment.EnrichmentProject.from_dict(
-            {
-                "api_key": self._api_key,
-                **enrichment_project_dict,
-            }
+
+        return enrichment.EnrichmentProject(
+            api_key=self._api_key,
+            id=enrichment_project_dict["id"],
+            name=enrichment_project_dict["name"],
+            target_column_in_dataset=enrichment_project_dict["target_column_in_dataset"],
+            created_at=enrichment_project_dict["created_at"],
         )
 
     def delete_enrichment_project(self, project_id: str) -> None:


### PR DESCRIPTION
This adds the ability to add, delete, and list Enrichment Projects.


#### Tests:
```py
>>> ep = studio.create_enrichment_project(dataset_id="ad409cee4080496587e770c9c6ba97b2", name="hello-world")

>>> ep.to_dict()
{'id': 'd498d2e62f9a4ec6910ff45cd09e47d2', 'name': 'hello-world', 'created_at': datetime.datetime(2024, 6, 6, 0, 1, 55), 'updated_at': datetime.datetime(2024, 6, 6, 0, 1, 55)}

>>> studio.get_enrichment_projects()
[<cleanlab_studio.studio.enrichment.EnrichmentProject object at 0x10041d750>, <cleanlab_studio.studio.enrichment.EnrichmentProject object at 0x12aeb4850>, <cleanlab_studio.studio.enrichment.EnrichmentProject object at 0x12aeb4ee0>, <cleanlab_studio.studio.enrichment.EnrichmentProject object at 0x12aeb4f10>]

>>> studio.delete_enrichment_project(project_id=ep.id)
Successfully deleted enrichment project: d498d2e62f9a4ec6910ff45cd09e47d2
```