### PR TITLE
change abort() to AuthError

### DIFF
--- a/cleanlab_studio/cli/login/login.py
+++ b/cleanlab_studio/cli/login/login.py
@@ -27,7 +27,11 @@ def login(prev_state: PreviousState, key: str) -> None:
     valid_key = validate_api_key(key)
     if not valid_key:
         raise AuthError(
-            "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key."
+            {
+                "code": "invalid_api_key",
+                "description":"API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.",
+            },
+            401,
         )
 
     # save API key

--- a/cleanlab_studio/cli/login/login.py
+++ b/cleanlab_studio/cli/login/login.py
@@ -26,9 +26,7 @@ def login(prev_state: PreviousState, key: str) -> None:
     # validate API key
     valid_key = validate_api_key(key)
     if not valid_key:
-        raise AuthError(
-            "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key."
-        )
+        raise AuthError()
 
     # save API key
     try:

--- a/cleanlab_studio/cli/login/login.py
+++ b/cleanlab_studio/cli/login/login.py
@@ -6,6 +6,7 @@ from cleanlab_studio.cli.decorators import previous_state
 from cleanlab_studio.internal.settings import CleanlabSettings
 import click
 from cleanlab_studio.internal.util import telemetry
+from cleanlab_studio.errors import AuthError
 
 
 @click.command(help="authentication for Cleanlab Studio")
@@ -25,7 +26,9 @@ def login(prev_state: PreviousState, key: str) -> None:
     # validate API key
     valid_key = validate_api_key(key)
     if not valid_key:
-        abort("API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.")
+        raise AuthError(
+            "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key."
+        )
 
     # save API key
     try:

--- a/cleanlab_studio/cli/login/login.py
+++ b/cleanlab_studio/cli/login/login.py
@@ -26,13 +26,7 @@ def login(prev_state: PreviousState, key: str) -> None:
     # validate API key
     valid_key = validate_api_key(key)
     if not valid_key:
-        raise AuthError(
-            {
-                "code": "invalid_api_key",
-                "description": "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.",
-            },
-            401,
-        )
+        raise AuthError("API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.")
 
     # save API key
     try:

--- a/cleanlab_studio/cli/login/login.py
+++ b/cleanlab_studio/cli/login/login.py
@@ -26,7 +26,9 @@ def login(prev_state: PreviousState, key: str) -> None:
     # validate API key
     valid_key = validate_api_key(key)
     if not valid_key:
-        raise AuthError("API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.")
+        raise AuthError(
+            "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key."
+        )
 
     # save API key
     try:

--- a/cleanlab_studio/cli/login/login.py
+++ b/cleanlab_studio/cli/login/login.py
@@ -29,7 +29,7 @@ def login(prev_state: PreviousState, key: str) -> None:
         raise AuthError(
             {
                 "code": "invalid_api_key",
-                "description":"API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.",
+                "description": "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.",
             },
             401,
         )

--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -101,7 +101,9 @@ class UnsupportedVersionError(HandledError):
 
 class AuthError(HandledError):
     def __init__(self) -> None:
-        super().__init__("API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.")
+        super().__init__(
+            "API key is invalid. Check https://app.cleanlab.ai/upload for your current API key."
+        )
 
 
 class InternalError(HandledError):

--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -101,7 +101,7 @@ class UnsupportedVersionError(HandledError):
 
 class AuthError(HandledError):
     def __init__(self) -> None:
-        super().__init__("invalid API key")
+        super().__init__("API key is invalid. Check https://app.cleanlab.ai/upload for your current API key.")
 
 
 class InternalError(HandledError):


### PR DESCRIPTION
Use AuthError instead of abort() for Invalid API keys to reduce the alert noise from wrong keys