### PR TITLE
[Data Enrichment] Add EnrichmentProject.preview, EnrichmentResult and EnrichmentOptions

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -644,10 +644,10 @@ def enrichment_preview(
     constrain_outputs: Optional[List[str]] = None,
     extraction_pattern: Optional[str] = None,
     indices: Optional[List[int]] = None,
-    optimize_prompt: Optional[bool] = None,
+    optimize_prompt: Optional[bool] = True,
     quality_preset: Optional[TLMQualityPreset] = "medium",
-    replacements: Optional[List[Dict[str, str]]] = None,
-    tlm_options: Optional[Dict[str, Any]] = None,
+    replacements: Optional[List[Dict[str, str]]] = [],
+    tlm_options: Optional[Dict[str, Any]] = {},
 ) -> JSONDict:
     """Call Enrichment Preview API and get response."""
     check_uuid_well_formed(project_id, "project_id")

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -653,9 +653,7 @@ def enrichment_preview(
 
     if request_json.get("replacements", None) is not None:
         if isinstance(request_json["replacements"], dict):
-            request_json["replacements"] = [
-                request_json["replacements"]
-            ]
+            request_json["replacements"] = [request_json["replacements"]]
         elif isinstance(request_json["replacements"], str):
             request_json["match_extraction"] = request_json["replacements"]
             request_json["replacements"] = None

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -652,8 +652,14 @@ def enrichment_preview(
     )
 
     if request_json.get("replacements", None) is not None:
-        if isinstance(request_json["replacements"], dict):
-            request_json["replacements"] = [request_json["replacements"]]
+        if isinstance(request_json["replacements"], tuple):
+            request_json["replacements"] = [
+                {request_json["replacements"][0], request_json["replacements"][1]}
+            ]
+        elif isinstance(request_json["replacements"], list):
+            request_json["replacements"] = [
+                {replacement[0], replacement[1]} for replacement in request_json["replacements"]
+            ]
         elif isinstance(request_json["replacements"], str):
             request_json["match_extraction"] = request_json["replacements"]
             request_json["replacements"] = None

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -645,9 +645,9 @@ def enrichment_preview(
     extraction_pattern: Optional[str] = None,
     indices: Optional[List[int]] = None,
     optimize_prompt: Optional[bool] = None,
+    quality_preset: Optional[TLMQualityPreset] = None,
     replacements: Optional[List[Dict[str, str]]] = None,
     tlm_options: Optional[Dict[str, Any]] = None,
-    tlm_quality_preset: Optional[TLMQualityPreset] = None,
 ) -> JSONDict:
     """Call Enrichment Preview API and get response."""
     check_uuid_well_formed(project_id, "project_id")
@@ -661,7 +661,7 @@ def enrichment_preview(
         optimize_prompt=optimize_prompt,
         replacements=replacements,
         tlm_options=tlm_options,
-        tlm_quality_preset=tlm_quality_preset,
+        tlm_quality_preset=quality_preset,
     )
 
     res = requests.post(

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -636,6 +636,29 @@ def list_all_enrichment_projects(api_key: str) -> List[JSONDict]:
     return all_projects
 
 
+def enrichment_preview(
+    api_key: str,
+    project_id: str,
+    options: JSONDict,
+    new_column_name: str,
+    indices: Optional[List[int]] = None,
+) -> JSONDict:
+    check_uuid_well_formed(project_id, "project_id")
+    request_json = dict(
+        **options,
+        new_column_name=new_column_name,
+        indices=indices,
+        project_id=project_id,
+    )
+    res = requests.post(
+        f"{enrichment_base_url}/preview",
+        headers=_construct_headers(api_key),
+        json=request_json,
+    )
+    handle_api_error(res)
+    return cast(JSONDict, res.json())
+
+
 def tlm_retry(func: Callable[..., Any]) -> Callable[..., Any]:
     """Implements TLM retry decorator, with special handling for rate limit retries."""
 

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -650,6 +650,16 @@ def enrichment_preview(
         indices=indices,
         project_id=project_id,
     )
+
+    if request_json.get("replacements", None) is not None:
+        if isinstance(request_json["replacements"], dict):
+            request_json["replacements"] = [
+                request_json["replacements"]
+            ]
+        elif isinstance(request_json["replacements"], str):
+            request_json["match_extraction"] = request_json["replacements"]
+            request_json["replacements"] = None
+
     res = requests.post(
         f"{enrichment_base_url}/preview",
         headers=_construct_headers(api_key),

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -645,7 +645,7 @@ def enrichment_preview(
     extraction_pattern: Optional[str] = None,
     indices: Optional[List[int]] = None,
     optimize_prompt: Optional[bool] = None,
-    quality_preset: Optional[TLMQualityPreset] = None,
+    quality_preset: Optional[TLMQualityPreset] = "medium",
     replacements: Optional[List[Dict[str, str]]] = None,
     tlm_options: Optional[Dict[str, Any]] = None,
 ) -> JSONDict:

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     pyspark_exists = False
 
-from cleanlab_studio.internal.types import JSONDict, SchemaOverride
+from cleanlab_studio.internal.types import JSONDict, SchemaOverride, TLMQualityPreset
 from cleanlab_studio.version import __version__
 from cleanlab_studio.errors import NotInstalledError
 from cleanlab_studio.internal.api.api_helper import (
@@ -638,31 +638,31 @@ def list_all_enrichment_projects(api_key: str) -> List[JSONDict]:
 
 def enrichment_preview(
     api_key: str,
-    project_id: str,
-    options: JSONDict,
     new_column_name: str,
+    project_id: str,
+    prompt: str,
+    constrain_outputs: Optional[List[str]] = None,
+    extraction_pattern: Optional[str] = None,
     indices: Optional[List[int]] = None,
+    optimize_prompt: Optional[bool] = None,
+    replacements: Optional[List[Dict[str, str]]] = None,
+    tlm_options: Optional[Dict[str, Any]] = None,
+    tlm_quality_preset: Optional[TLMQualityPreset] = None,
 ) -> JSONDict:
+    """Call Enrichment Preview API and get response."""
     check_uuid_well_formed(project_id, "project_id")
     request_json = dict(
-        **options,
         new_column_name=new_column_name,
-        indices=indices,
         project_id=project_id,
+        prompt=prompt,
+        constrain_outputs=constrain_outputs,
+        extraction_pattern=extraction_pattern,
+        indices=indices,
+        optimize_prompt=optimize_prompt,
+        replacements=replacements,
+        tlm_options=tlm_options,
+        tlm_quality_preset=tlm_quality_preset,
     )
-
-    if request_json.get("replacements", None) is not None:
-        if isinstance(request_json["replacements"], tuple):
-            request_json["replacements"] = [
-                {request_json["replacements"][0], request_json["replacements"][1]}
-            ]
-        elif isinstance(request_json["replacements"], list):
-            request_json["replacements"] = [
-                {replacement[0], replacement[1]} for replacement in request_json["replacements"]
-            ]
-        elif isinstance(request_json["replacements"], str):
-            request_json["match_extraction"] = request_json["replacements"]
-            request_json["replacements"] = None
 
     res = requests.post(
         f"{enrichment_base_url}/preview",

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -214,7 +214,7 @@ def _validate_enrichment_options(options: EnrichmentOptions) -> None:
         )
 
     # Validate the regex
-    def _validate_tuple_is_replacement(t: Tuple) -> None:
+    def _validate_tuple_is_replacement(t: Tuple[Any, ...]) -> None:
         if isinstance(t, tuple) and len(t) == 2 and all(isinstance(x, str) for x in t):
             return None
         raise ValueError(REGEX_PARAMETER_ERROR_MESSAGE)
@@ -264,7 +264,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
     _final_result_name: str
 
     @classmethod
-    def from_dict(cls, json_dict: Dict) -> EnrichmentPreviewResult:
+    def from_dict(cls, json_dict: Dict[str, Any]) -> EnrichmentPreviewResult:
         new_column_name_mapping = json_dict["new_column_name_mapping"]
 
         # Prepare the results DataFrame from the 'results' list
@@ -307,7 +307,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
         return instance
 
     # undecided on whether to include this method
-    def get_preview_status(self) -> Dict:
+    def get_preview_status(self) -> Dict[str, bool | int]:
         """Get the status of the preview operation."""
         return {
             "is_timeout": self._is_timeout,

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -111,7 +111,7 @@ class EnrichmentProject:
         response = api.enrichment_preview(
             api_key=self._api_key,
             project_id=self._id,
-            options=cast(JSONDict, options),    # https://stackoverflow.com/a/76515675
+            options=cast(JSONDict, options),  # https://stackoverflow.com/a/76515675
             new_column_name=new_column_name,
             indices=indices,
         )
@@ -188,6 +188,7 @@ class EnrichmentResult:
 
         joined_data = original_data.join(df, how="left")
         return joined_data
+
 
 # undecided on whether to include this class or just use EnrichmentResult
 # for now, I get some buy-in from Anish. Need to finalize after preview endpoint reach a stable state

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -6,9 +6,16 @@ Methods for interfacing with Enrichment Projects.
 
 from __future__ import annotations
 from datetime import datetime
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, List, TypedDict, Tuple
+
+import pandas as pd
 
 from cleanlab_studio.internal.api import api
+from cleanlab_studio.internal.types import JSONDict
+from cleanlab_studio.studio.trustworthy_language_model import TLMOptions
+
+RegExp = str
+Replacement = Tuple[RegExp, str]
 
 
 def _response_timestamp_to_datetime(timestamp_string: str) -> datetime:
@@ -92,3 +99,82 @@ class EnrichmentProject:
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
+
+    def preview(
+        self,
+        options: EnrichmentOptions,
+        *,
+        new_column_name: str,
+        indices: Optional[List[int]] = None,
+        disable_warnings: bool = False,
+    ) -> EnrichmentResult:
+        response = api.enrichment_preview(
+            api_key=self._api_key,
+            project_id=self._id,
+            options=options,
+            new_column_name=new_column_name,
+            indices=indices,
+        )
+        return EnrichmentResult.from_dict(response)
+
+
+class EnrichmentOptions(TypedDict):
+    """Options for enriching a dataset with a Trustworthy Language Model (TLM).
+
+    ref: https://github.com/cleanlab/cleanlab-studio/blob/main/cleanlab_studio/utils/data_enrichment/enrich.py#L34
+
+    Args:
+        prompt (str): Formatted f-string, that contains both the prompt, and names of columns to embed.
+            **Example:** "Is this a numeric value, answer Yes or No only. Value: {column_name}"
+        replacements (Union[Replacement, List[Replacement]]):             If a string value is passed in, a regex match will be performed and the matched pattern will be returned (if the pattern cannot be matched, None will be returned).
+            Specifically the provided string will be passed into Python's `re.match()` method.
+            Pass in a tuple `(R1, R2)` instead if you wish to perform find and replace operations rather than matching/extraction.
+            `R1` should be a string containing the regex pattern to match, and `R2` should be a string to replace matches with.
+            Pass in a list of tuples instead if you wish to apply multiple replacements. Replacements will be applied in the order they appear in the list.
+            Note that you cannot pass in a list of strings (chaining of multiple regex processing steps is only allowed for replacement operations).
+
+            These tuples specify the desired patterns to match and replace from the raw LLM response,
+            This regex processing is useful in settings where you are unable to prompt the LLM to generate valid outputs 100% of the time,
+            but can easily transform the raw LLM outputs to be valid through regular expressions that extract and replace parts of the raw output string.
+            When this regex is applied, the processed results can be seen ithe ``{new_column_name}`` column, and the raw outpus (before any regex processing)
+            will be saved in the ``{new_column_name}_log`` column of the results dataframe.
+
+            **Example 1:** ``regex = '.*The answer is: (Bird|[Rr]abbit).*'`` will extract strings that are the words 'Bird', 'Rabbit' or 'rabbit' after the characters "The answer is: " from the raw response.
+            **Example 2:** ``regex = [('True', 'T'), ('False', 'F')]`` will replace the words True and False with T and F.
+            **Example 3:** ``regex = (' Explanation:.*', '') will remove everything after and including the words "Explanation:".
+            For instance, the response "True. Explanation: 3+4=7, and 7 is an odd number." would return "True." after the regex replacement.
+
+        constrain_outputs (List[str], optional): List of all possible output values for the `metadata` column.
+            If specified, every entry in the `metadata` column will exactly match one of these values (for less open-ended data enrichment tasks). If None, the `metadata` column can contain arbitrary values (for more open-ended data enrichment tasks).
+           There may be additional transformations applied to ensure the returned value is one of these. If regex is also specified, then these transformations occur after your regex is applied.
+            If `optimize_prompt` is True, the prompt will be automatically adjusted to include a statement that the response must match one of the `constrain_outputs`.
+        optimize_prompt (bool, default = True): When False, your provided prompt will not be modified in any way. When True, your provided prompt may be automatically adjusted in an effort to produce better results.
+            For instance, if the constrain_outputs are constrained, we may automatically append the following statement to your prompt: "Your answer must exactly match one of the following values: `constrain_outputs`."
+        indices (Tuple[int, int] | List[int], optional): What subset of the supplied data rows to generate metadata for. If None, we run on all of the data.
+            This can be either a list of unique indices or a range. These indices are passed into pandas ``.iloc`` method, so should be integers based on row order as opposed to row-index labels pointing to `df.index`.
+            We advise against collecting results for all of your data at first. First collect results for a smaller data subset, and use this subset to experiment with different values of the `prompt` or `regex` arguments. Only once the results look good for your subset should you run on the full dataset.
+        new_column_name (str): Optional name for the returned enriched column. Name acts as a prefix appended to all additional columns that are returned.
+    """
+
+    prompt: str
+    replacements: Optional[Union[Replacement, List[Replacement]]]
+    optimize_prompt: Optional[bool]
+    tlm_options: Optional[TLMOptions]
+    constrain_outputs: Optional[List[str]]
+
+
+class EnrichmentResult:
+    _indices: Optional[List[int]]
+    _results: pd.DataFrame
+
+    def from_dict(self, json_dict: JSONDict) -> None:
+        pass
+
+    def to_list(self) -> List[Tuple[Optional[str], float]]:
+        pass
+
+    def details(self) -> pd.DataFrame:
+        return self._results
+
+    def join(self, data: pd.DataFrame, *, with_details: bool = False) -> pd.DataFrame:
+        pass

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -256,7 +256,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
 
     @classmethod
     def from_dict(cls, json_dict: Dict[str, Any]) -> EnrichmentPreviewResult:
-        enrichment_column_name_mapping = json_dict["enrichment_column_name_mapping"]
+        new_column_name_mapping = json_dict["new_column_name_mapping"]
 
         # Prepare the results DataFrame from the 'results' list
         results = json_dict["results"]
@@ -276,12 +276,12 @@ class EnrichmentPreviewResult(EnrichmentResult):
         ]
         df.rename(
             columns={
-                FINAL_RESULT_COLUMN_NAME: enrichment_column_name_mapping[FINAL_RESULT_COLUMN_NAME],
-                TRUSTWORTHY_SCORE_COLUMN_NAME: enrichment_column_name_mapping[
+                FINAL_RESULT_COLUMN_NAME: new_column_name_mapping[FINAL_RESULT_COLUMN_NAME],
+                TRUSTWORTHY_SCORE_COLUMN_NAME: new_column_name_mapping[
                     TRUSTWORTHY_SCORE_COLUMN_NAME
                 ],
-                RAW_RESULT_COLUMN_NAME: enrichment_column_name_mapping[RAW_RESULT_COLUMN_NAME],
-                LOG_COLUMN_NAME: enrichment_column_name_mapping[LOG_COLUMN_NAME],
+                RAW_RESULT_COLUMN_NAME: new_column_name_mapping[RAW_RESULT_COLUMN_NAME],
+                LOG_COLUMN_NAME: new_column_name_mapping[LOG_COLUMN_NAME],
             },
             inplace=True,
         )
@@ -293,7 +293,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
         instance._is_timeout = json_dict["is_timeout"]
         instance._completed_jobs_count = json_dict["completed_jobs_count"]
         instance._failed_jobs_count = json_dict["failed_jobs_count"]
-        instance._final_result_name = enrichment_column_name_mapping[FINAL_RESULT_COLUMN_NAME]
+        instance._final_result_name = new_column_name_mapping[FINAL_RESULT_COLUMN_NAME]
 
         return instance
 

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -121,6 +121,7 @@ class EnrichmentProject:
             )
         return epr
 
+
 class EnrichmentOptions(TypedDict):
     """Options for enriching a dataset with a Trustworthy Language Model (TLM).
 
@@ -210,17 +211,17 @@ class EnrichmentPreviewResult(EnrichmentResult):
 
         # Select and rename the columns to match the expected format
         df = df[["final_result", "trustworthy_score", "log"]]
-        df.rename(columns={
-            "final_result": new_column_name,
-            "trustworthy_score": f"{new_column_name}_trustworthy_score",
-            "log": f"{new_column_name}_log"
-        }, inplace=True)
+        df.rename(
+            columns={
+                "final_result": new_column_name,
+                "trustworthy_score": f"{new_column_name}_trustworthy_score",
+                "log": f"{new_column_name}_log",
+            },
+            inplace=True,
+        )
 
         # Create an instance of EnrichmentPreviewResult
-        instance = cls(
-            results=df,
-            new_column_name=new_column_name
-        )
+        instance = cls(results=df, new_column_name=new_column_name)
 
         # Set the additional attributes
         instance._indices = df.index.tolist()
@@ -231,7 +232,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
         instance._failed_count = json_dict["failed_jobs_count"]
 
         return instance
-    
+
     def get_preview_status(self) -> Dict:
         return {
             "is_timeout": self._is_timeout,
@@ -239,11 +240,11 @@ class EnrichmentPreviewResult(EnrichmentResult):
             "successful_count": self._successful_count,
             "failed_count": self._failed_count,
         }
-    
+
     def join(self, original_data: pd.DataFrame, *, with_details: bool = False) -> pd.DataFrame:
-        """Join the original data with the enrichment results. 
+        """Join the original data with the enrichment results.
         The result only contains those rows that were enriched by preview.
-        
+
         Args:
             original_data (pd.DataFrame): The original data to join with the enrichment results.
             with_details (bool): If `with_details` is True, the details of the enrichment results will be included in the output DataFrame.

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -149,7 +149,7 @@ class EnrichmentProject:
             replacements=replacements,
             tlm_options=cast(Dict[str, Any], options.get("tlm_options"))
             if options.get("tlm_options")
-            else None,
+            else {},
         )
         epr = EnrichmentPreviewResult.from_dict(response)
 
@@ -203,11 +203,6 @@ def _validate_enrichment_options(options: EnrichmentOptions) -> None:
     # Validate the prompt
     if len(options["prompt"]) == 0:
         raise ValueError("The 'prompt' parameter must be a non-empty string.")
-    prompt_pattern = r"\$\{.*?\}"
-    if re.search(prompt_pattern, options["prompt"]):
-        raise ValueError(
-            "The 'prompt' parameter should contains at least one dataset column name as '$\{my_column_name\}'."
-        )
 
     # Validate the regex
     def _validate_tuple_is_replacement(t: Tuple[Any, ...]) -> None:
@@ -323,7 +318,5 @@ class EnrichmentPreviewResult(EnrichmentResult):
         if not with_details:
             df = self._results[[self._final_result_name]]
         joined_data = original_data.join(df, how="inner")
-
-        joined_data = joined_data.drop(columns=[ROW_ID_COLUMN_NAME])
 
         return joined_data

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -167,7 +167,7 @@ class EnrichmentResult:
     _indices: Optional[List[int]]
     _results: pd.DataFrame
 
-    def from_dict(self, json_dict: JSONDict) -> None:
+    def from_dict(self, json_dict: JSONDict) -> EnrichmentResult:
         pass
 
     def to_list(self) -> List[Tuple[Optional[str], float]]:

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -149,7 +149,7 @@ class EnrichmentProject:
             extraction_pattern=extraction_pattern,
             indices=indices,
             optimize_prompt=options.get("optimize_prompt"),
-            prompt=options.get("prompt"),
+            prompt=options["prompt"],
             quality_preset=options.get("quality_preset"),
             replacements=replacements,
             tlm_options=options.get("tlm_options"),

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -115,9 +115,8 @@ class EnrichmentProject:
         *,
         new_column_name: str,
         indices: Optional[List[int]] = None,
-        disable_warnings: bool = False,
     ) -> EnrichmentPreviewResult:
-        """Run a subset of data through the enrichment service and preview the results."""
+        """Enrich a subset of data for a preview."""
         extraction_pattern = None
         replacements: List[Dict[str, str]] = []
 
@@ -153,10 +152,7 @@ class EnrichmentProject:
             else None,
         )
         epr = EnrichmentPreviewResult.from_dict(response)
-        if not disable_warnings and epr._is_timeout:
-            warnings.warn(
-                "Warning: The preview operation timed out for a subset of data. Set those results to None."
-            )
+
         return epr
 
 
@@ -265,7 +261,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
 
     @classmethod
     def from_dict(cls, json_dict: Dict[str, Any]) -> EnrichmentPreviewResult:
-        new_column_name_mapping = json_dict["new_column_name_mapping"]
+        enrichment_column_name_mapping = json_dict["enrichment_column_name_mapping"]
 
         # Prepare the results DataFrame from the 'results' list
         results = json_dict["results"]
@@ -285,12 +281,12 @@ class EnrichmentPreviewResult(EnrichmentResult):
         ]
         df.rename(
             columns={
-                FINAL_RESULT_COLUMN_NAME: new_column_name_mapping[FINAL_RESULT_COLUMN_NAME],
-                TRUSTWORTHY_SCORE_COLUMN_NAME: new_column_name_mapping[
+                FINAL_RESULT_COLUMN_NAME: enrichment_column_name_mapping[FINAL_RESULT_COLUMN_NAME],
+                TRUSTWORTHY_SCORE_COLUMN_NAME: enrichment_column_name_mapping[
                     TRUSTWORTHY_SCORE_COLUMN_NAME
                 ],
-                RAW_RESULT_COLUMN_NAME: new_column_name_mapping[RAW_RESULT_COLUMN_NAME],
-                LOG_COLUMN_NAME: new_column_name_mapping[LOG_COLUMN_NAME],
+                RAW_RESULT_COLUMN_NAME: enrichment_column_name_mapping[RAW_RESULT_COLUMN_NAME],
+                LOG_COLUMN_NAME: enrichment_column_name_mapping[LOG_COLUMN_NAME],
             },
             inplace=True,
         )
@@ -302,7 +298,7 @@ class EnrichmentPreviewResult(EnrichmentResult):
         instance._is_timeout = json_dict["is_timeout"]
         instance._completed_jobs_count = json_dict["completed_jobs_count"]
         instance._failed_jobs_count = json_dict["failed_jobs_count"]
-        instance._final_result_name = new_column_name_mapping[FINAL_RESULT_COLUMN_NAME]
+        instance._final_result_name = enrichment_column_name_mapping[FINAL_RESULT_COLUMN_NAME]
 
         return instance
 

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -6,7 +6,7 @@ Methods for interfacing with Enrichment Projects.
 
 from __future__ import annotations
 from datetime import datetime
-from typing import Any, Dict, Optional, Union, List, TypedDict, Tuple
+from typing import Any, Dict, Optional, Union, List, TypedDict, Tuple, cast
 
 import pandas as pd
 
@@ -107,10 +107,11 @@ class EnrichmentProject:
         indices: Optional[List[int]] = None,
         disable_warnings: bool = False,
     ) -> EnrichmentPreviewResult:
+        """Run a subset of data through the enrichment service and preview the results."""
         response = api.enrichment_preview(
             api_key=self._api_key,
             project_id=self._id,
-            options=options,
+            options=cast(JSONDict, options),    # https://stackoverflow.com/a/76515675
             new_column_name=new_column_name,
             indices=indices,
         )
@@ -188,7 +189,8 @@ class EnrichmentResult:
         joined_data = original_data.join(df, how="left")
         return joined_data
 
-
+# undecided on whether to include this class or just use EnrichmentResult
+# for now, I get some buy-in from Anish. Need to finalize after preview endpoint reach a stable state
 class EnrichmentPreviewResult(EnrichmentResult):
     _indices: List[int]
     _errors: Dict
@@ -233,7 +235,9 @@ class EnrichmentPreviewResult(EnrichmentResult):
 
         return instance
 
+    # undecided on whether to include this method
     def get_preview_status(self) -> Dict:
+        """Get the status of the preview operation."""
         return {
             "is_timeout": self._is_timeout,
             "total_count": self._total_count,


### PR DESCRIPTION
# Description

Add EnrichmentProject.preview, EnrichmentResult and EnrichmentOptions


# Tests
## Update 19th:
```


if __name__ == "__main__":
    import os

    os.environ["CLEANLAB_API_BASE_URL"] = "https://api.dev-bc26qf4m.cleanlab.ai/api"
    from cleanlab_studio import Studio
    from cleanlab_studio.studio.enrichment import (
        EnrichmentOptions,
        TLMOptions,
        EnrichmentProject,
        EnrichmentPreviewResult,
    )

    api_key = "xxx"
    dataset_id = "xxx"
    project_id = "xxx"
    studio = Studio(api_key)
    # enrichment_project: EnrichmentProject = studio.create_enrichment_project("aaron_test", dataset_id=dataset_id)
    enrichment_project = EnrichmentProject(
        api_key=api_key,
        id=project_id,
        name="aaron_test",
        created_at="Thu, 01 Jan 1970 00:00:00 UTC",
    )
    print(enrichment_project.id)
    erich_options = EnrichmentOptions(
        prompt="is ${People} a number?",
        quality_preset="low",
    )
    result: EnrichmentPreviewResult = enrichment_project.preview(
        options=erich_options, new_column_name="random", indices=[3, 4, 7]
    )

    print(result.details())
    print(
        result.join(
            pd.DataFrame({"People": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]}),
            with_details=True,
        )
    )
    print(result.get_preview_status())
```
output:
```
                                                   random  ...  random_log
row_id                                                     ...            
3       No, ${People} is not a number. It appears to b...  ...        None
7       No, ${People} is not a number. It appears to b...  ...        None
4       No, ${People} is not a number. It appears to b...  ...        None

[3 rows x 4 columns]
  People                                             random  ...                                         random_raw random_log
3      4  No, ${People} is not a number. It appears to b...  ...  No, ${People} is not a number. It appears to b...       None
4      5  No, ${People} is not a number. It appears to b...  ...  No, ${People} is not a number. It appears to b...       None
7      8  No, ${People} is not a number. It appears to b...  ...  No, ${People} is not a number. It appears to b...       None
```
## Update Jun 18:
prepare payload:
```python
    ep = EnrichmentProject(api_key="test", id=str(uuid.uuid4()), name="test")
    options = EnrichmentOptions(
            prompt="Is this a numeric value, answer Yes or No only. Value: {column_name}",
            constrain_outputs=["Yes", "No"],
            optimize_prompt=True,
            quality_preset="high",
            regex=".*The answer is: (Bird|[Rr]abbit).*",
            tlm_options=TLMOptions(num_candidate_responses=5)
        )
    ep.preview(
        options=options,
        new_column_name="cool_column",
        indices=[1, 2, 3],
        disable_warnings=False,
    )
```
payload print:
```
{'constrain_outputs': ['Yes', 'No'],
 'extraction_pattern': '.*The answer is: (Bird|[Rr]abbit).*',
 'indices': [1, 2, 3],
 'new_column_name': 'cool_column',
 'optimize_prompt': True,
 'project_id': '6469030b-2d30-4f02-a578-162e5d2b47b9',
 'prompt': 'Is this a numeric value, answer Yes or No only. Value: '
           '{column_name}',
 'replacements': [],
 'tlm_options': {'num_candidate_responses': 5},
 'tlm_quality_preset': 'high'}
```

error out `regex = [("a", "b", "c"), (1, 2)]`
raised error:
`ValueError: The 'regex' parameter must be a string, a tuple(str, str), or a list of tuple(str, str).`

for output:
```python
    json_response = {
        "completed_jobs_count": 3,
        "failed_jobs_count": 0,
        "is_timeout": False,
        "results": [
            {
                "final_result": "yes2",
                "log": "xyz",
                "row_id": 2,
                "raw_result": "It does.",
                "trustworthy_score": 0.5
            },
            {
                "final_result": "yes5",
                "log": "def",
                "row_id": 5,
                "raw_result": "It does.",
                "trustworthy_score": 0.5
            },
            {
                "final_result": "yes3",
                "log": "abc",
                "row_id": 3,
                "raw_result": "It does.",
                "trustworthy_score": 0.5
            }
        ],
        "new_column_name_mapping": {
            "final_result": "cool_column",
            "trustworthy_score": "cool_column_trustworthiness_score",
            "raw_result": "cool_column_raw",
            "log": "cool_column_log"
        }
    }

    x = EnrichmentPreviewResult.from_dict(json_response)
    print(x.details())
    fake_data = pd.DataFrame({"row_id": [1, 2, 3, 4, 5, 6, 7], "text": ["It does.", "It does.", "It does.", "It does.", "It does.", "It does.", "It does."], "metadata": ["yes", "no", "yes", "no", "yes", "no", "yes"]})

    print(x.join(fake_data, with_details=True))
```
output:
```
       cool_column  cool_column_trustworthiness_score cool_column_raw cool_column_log
row_id                                                                               
2             yes2                                0.5        It does.             xyz
5             yes5                                0.5        It does.             def
3             yes3                                0.5        It does.             abc
       text metadata cool_column  cool_column_trustworthiness_score cool_column_raw cool_column_log
2  It does.      yes        yes2                                0.5        It does.             xyz
3  It does.       no        yes3                                0.5        It does.             abc
5  It does.       no        yes5                                0.5        It does.             def
```


----------
## update:
mocked the `api.enrichment_preview` so that we can see the payload going out and make a dedicated response.
the payload sending out from `enrichment_preview`
```python
    eo = EnrichmentOptions(
        prompt="Is this a numeric value, answer Yes or No only.",
        constrain_outputs=["apple", "banana", "cherry"],
        optimize_prompt=True,
        replacements=".*The answer is: (Bird|[Rr]abbit).*",
        tlm_options=TLMOptions(
            model="gpt2",
            max_length=50,
            temperature=0.7,
        ),
    )
```
when reach to the api
```
{   'constrain_outputs': ['apple', 'banana', 'cherry'],
    'indices': [2, 1, 4],
    'match_extraction': '.*The answer is: (Bird|[Rr]abbit).*',
    'new_column_name': 'best_column',
    'optimize_prompt': True,
    'project_id': '5f9c677509c14ace8be4a9d5bc5a1728',
    'prompt': 'Is this a numeric value, answer Yes or No only.',
    'replacements': None,
    'tlm_options': {'max_length': 50, 'model': 'gpt2', 'temperature': 0.7}}
```
returned response, manually created
```
    json_response = {
        "completed_jobs_count": 3,
        "failed_jobs_count": 0,
        "is_timeout": False,
        "new_column_name": "metadata",
        "errors": {},
        "results": [
            {
                "final_result": "yes",
                "log": "xyz",
                "row_id": 2,
                "raw_result": "It does.",
                "trustworthy_score": 0.5
            },
            {
                "final_result": "yes",
                "log": "def",
                "row_id": 5,
                "raw_result": "It does.",
                "trustworthy_score": 0.5
            },
            {
                "final_result": "yes",
                "log": "abc",
                "row_id": 3,
                "raw_result": "It does.",
                "trustworthy_score": 0.5
            }
        ]
    }
```
```python
    print(f"type of the result: {type(preview_result)}\n")
    print(f"status: {preview_result.get_preview_status()}\n")
    print(f"details: {preview_result.details()}\n")
    print(f"join with detail: ")
    print(preview_result.join(pd.DataFrame({"some_data": [1,2,3,4,5]}), with_details=True))
    print("")
    print(f"join without details: ")
    print(preview_result.join(pd.DataFrame({"some_data": [1,2,3,4,5]}), with_details=False))
```
print output:
```
type of the result: <class '__main__.EnrichmentPreviewResult'>

status: {'is_timeout': False, 'total_count': 3, 'successful_count': 3, 'failed_count': 0}

details:        metadata  metadata_trustworthy_score metadata_log
row_id                                                  
2           yes                         0.5          xyz
5           yes                         0.5          def
3           yes                         0.5          abc

join with detail: 
   some_data metadata  metadata_trustworthy_score metadata_log
2          3      yes                         0.5          xyz
3          4      yes                         0.5          abc

join without details: 
   some_data metadata
2          3      yes
3          4      yes
```



## Update:
```
json_response = {
    "completed_jobs_count": 3,
    "failed_jobs_count": 0,
    "is_timeout": False,
    "new_column_name": "metadata",
    "errors": {},
    "results": [
        {
            "final_result": "yes",
            "log": "xyz",
            "row_id": 2,
            "raw_result": "It does.",
            "trustworthy_score": 0.5
        },
        {
            "final_result": "yes",
            "log": "def",
            "row_id": 5,
            "raw_result": "It does.",
            "trustworthy_score": 0.5
        },
        {
            "final_result": "yes",
            "log": "abc",
            "row_id": 3,
            "raw_result": "It does.",
            "trustworthy_score": 0.5
        }
    ]
}
```
```python
enrichment_preview_result = EnrichmentPreviewResult.from_dict(json_response)
print(enrichment_preview_result._results)
#       metadata  metadata_trustworthy_score metadata_log
#row_id                                                  
#2           yes                         0.5          xyz
#5           yes                         0.5          def
#3           yes                         0.5          abc
```
```python
data = {
    'row_id': [1, 2, 3, 4, 5],
    'existing_column': ['a', 'b', 'c', 'd', 'e']
}
other_df = pd.DataFrame(data).set_index('row_id')

# Perform the join
joined_df = enrichment_preview_result.join(other_df, False)

# Display the result
print(joined_df)
#       existing_column metadata
#row_id                         
#2                    b      yes
#3                    c      yes
#5                    e      yes

print(enrichment_preview_result.join(other_df, True)
#       existing_column metadata  metadata_trustworthy_score metadata_log
#row_id                                                                  
#2                    b      yes                         0.5          xyz
#3                    c      yes                         0.5          abc
#5                    e      yes                         0.5          def

```


==========
Assume the response:
```
{
        "new_column_name": "cool_column",
        "indices": [3, 27, 311],
        "results": {
            "3": ["result1", 0.9],
            "27": ["result2", 0.8],
            "311": ["result3", 0.7],
        },
        "errors": {},
        "is_timeout": False,
        "total_count": 3,
        "successful_count": 3,
        "failed_count": 0,
    }
```
then 
```python
enrichment_preview_result = EnrichmentPreviewResult.from_dict(response)

print(enrichment_preview_result.get_preview_status())
# {'is_timeout': False, 'total_count': 3, 'successful_count': 3, 'failed_count': 0}

print(enrichment_preview_result.details())
#         cool_column  cool_column_trustworthiness
# 3       result1                          0.9
# 27      result2                          0.8
# 311     result3                          0.7
```