### PR TITLE
Add logs to TLM outputs + allow perplexity as input

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -667,7 +667,6 @@ async def tlm_get_confidence_score(
     api_key: str,
     prompt: str,
     response: str,
-    input_metadata: Optional[JSONDict],
     quality_preset: str,
     options: Optional[JSONDict],
     rate_handler: TlmRateHandler,
@@ -681,7 +680,6 @@ async def tlm_get_confidence_score(
         api_key (str): studio API key for auth
         prompt (str): prompt for TLM to get confidence score for
         response (str): response for TLM to get confidence score for
-        input_metadata (JSONDict): additional input metadata for TLM
         quality_preset (str): quality preset to use to generate confidence score
         options (JSONDict): additional parameters for TLM
         rate_handler (TlmRateHandler): concurrency handler used to manage TLM request rate
@@ -703,7 +701,6 @@ async def tlm_get_confidence_score(
                 json=dict(
                     prompt=prompt,
                     response=response,
-                    input_metadata=input_metadata or {},
                     quality=quality_preset,
                     options=options or {},
                 ),

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -667,6 +667,7 @@ async def tlm_get_confidence_score(
     api_key: str,
     prompt: str,
     response: str,
+    logprobs: float,
     quality_preset: str,
     options: Optional[JSONDict],
     rate_handler: TlmRateHandler,
@@ -680,6 +681,7 @@ async def tlm_get_confidence_score(
         api_key (str): studio API key for auth
         prompt (str): prompt for TLM to get confidence score for
         response (str): response for TLM to get confidence score for
+        logprobs (float): log probabilities associated with the given responses
         quality_preset (str): quality preset to use to generate confidence score
         options (JSONDict): additional parameters for TLM
         rate_handler (TlmRateHandler): concurrency handler used to manage TLM request rate
@@ -699,7 +701,11 @@ async def tlm_get_confidence_score(
             res = await client_session.post(
                 f"{tlm_base_url}/get_confidence_score",
                 json=dict(
-                    prompt=prompt, response=response, quality=quality_preset, options=options or {}
+                    prompt=prompt,
+                    response=response,
+                    logprobs=logprobs,
+                    quality=quality_preset,
+                    options=options or {},
                 ),
                 headers=_construct_headers(api_key),
             )

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -667,7 +667,7 @@ async def tlm_get_confidence_score(
     api_key: str,
     prompt: str,
     response: str,
-    logprobs: float,
+    input_metadata: Optional[JSONDict],
     quality_preset: str,
     options: Optional[JSONDict],
     rate_handler: TlmRateHandler,
@@ -681,7 +681,7 @@ async def tlm_get_confidence_score(
         api_key (str): studio API key for auth
         prompt (str): prompt for TLM to get confidence score for
         response (str): response for TLM to get confidence score for
-        logprobs (float): log probabilities associated with the given responses
+        input_metadata (JSONDict): additional input metadata for TLM
         quality_preset (str): quality preset to use to generate confidence score
         options (JSONDict): additional parameters for TLM
         rate_handler (TlmRateHandler): concurrency handler used to manage TLM request rate
@@ -703,7 +703,7 @@ async def tlm_get_confidence_score(
                 json=dict(
                     prompt=prompt,
                     response=response,
-                    logprobs=logprobs,
+                    input_metadata=input_metadata or {},
                     quality=quality_preset,
                     options=options or {},
                 ),

--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -8,3 +8,4 @@ _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 TLM_MAX_TOKEN_RANGE: Tuple[int, int] = (64, 512)  # (min, max)
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: Tuple[int, int] = (1, 20)  # (min, max)
 TLM_NUM_CONSISTENCY_SAMPLES_RANGE: Tuple[int, int] = (0, 20)  # (min, max)
+TLM_VALID_LOG_OPTIONS: set[str] = {"logprobs"}

--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -8,4 +8,5 @@ _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 TLM_MAX_TOKEN_RANGE: Tuple[int, int] = (64, 512)  # (min, max)
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: Tuple[int, int] = (1, 20)  # (min, max)
 TLM_NUM_CONSISTENCY_SAMPLES_RANGE: Tuple[int, int] = (0, 20)  # (min, max)
-TLM_VALID_LOG_OPTIONS: set[str] = {"logprobs"}
+TLM_VALID_LOG_OPTIONS: set[str] = {"perplexity"}
+TLM_VALID_GET_TRUSTWORTHINESS_SCORE_KWARGS: set[str] = {"perplexity"}

--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Set
 
 # TLM constants
 # prepend constants with _ so that they don't show up in help.cleanlab.ai docs
@@ -8,5 +8,5 @@ _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 TLM_MAX_TOKEN_RANGE: Tuple[int, int] = (64, 512)  # (min, max)
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: Tuple[int, int] = (1, 20)  # (min, max)
 TLM_NUM_CONSISTENCY_SAMPLES_RANGE: Tuple[int, int] = (0, 20)  # (min, max)
-TLM_VALID_LOG_OPTIONS: set[str] = {"perplexity"}
-TLM_VALID_GET_TRUSTWORTHINESS_SCORE_KWARGS: set[str] = {"perplexity"}
+TLM_VALID_LOG_OPTIONS: Set[str] = {"perplexity"}
+TLM_VALID_GET_TRUSTWORTHINESS_SCORE_KWARGS: Set[str] = {"perplexity"}

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -181,15 +181,15 @@ def validate_tlm_options(options: Any) -> None:
                     f"Invalid type {type(val)}, use_self_reflection must be a boolean"
                 )
 
-        elif option == "logs":
+        elif option == "log":
             if not isinstance(val, list):
-                raise ValidationError(f"Invalid type {type(val)}, logs must be a list of strings.")
+                raise ValidationError(f"Invalid type {type(val)}, log must be a list of strings.")
 
-            invalid_log_options = set(option["logs"]) - TLM_VALID_LOG_OPTIONS
+            invalid_log_options = set(option["log"]) - TLM_VALID_LOG_OPTIONS
 
             if invalid_log_options:
                 raise ValidationError(
-                    f"Invalid options for logs: {invalid_log_options}. Valid options include: {TLM_VALID_LOG_OPTIONS}"
+                    f"Invalid options for log: {invalid_log_options}. Valid options include: {TLM_VALID_LOG_OPTIONS}"
                 )
 
 

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -232,8 +232,8 @@ def process_response_and_kwargs(
                 )
 
     # if kwargs_dict is empty, return the responses (save the transformation computations below)
-    if len(kwargs_dict) == 0:
-        return response
+    # if len(kwargs_dict) == 0:
+    #     return response
 
     # format responses and kwargs into the appropriate formats
     combined_response = {"response": response, **kwargs_dict}

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -59,7 +59,8 @@ def validate_tlm_prompt_response(
             )
 
     elif isinstance(prompt, Sequence):
-        if not isinstance(response, Sequence):
+        # str is considered a Sequence, we want to explicitly check that response is not a string
+        if not isinstance(response, Sequence) or isinstance(response, str):
             raise ValidationError(
                 "response type must match prompt type. "
                 f"prompt was provided as type {type(prompt)} but response is of type {type(response)}"
@@ -206,19 +207,18 @@ def process_get_trustworthiness_score_kwargs(
     # checking validity/format of each input kwarg, each one might require a different format
     for key, val in kwargs_dict.items():
         if key == "perplexity":
-            if val is None or isinstance(val, float) or isinstance(val, int):
-                if not isinstance(prompt, str):
+            if isinstance(prompt, str):
+                if not (val is None or isinstance(val, float) or isinstance(val, int)):
                     raise ValidationError(
-                        f"Invalid type {type(val)}, perplexity should be a float if prompt is a str, and should be a sequence if prompt is a sequence"
+                        f"Invalid type {type(val)}, perplexity should be a float when prompt is a str."
                     )
-                # TODO: should we raise warning if perplexity is None?
                 if val is not None and not 0 <= val <= 1:
                     raise ValidationError("Perplexity values must be between 0 and 1")
 
-            elif isinstance(val, Sequence):
-                if not isinstance(prompt, Sequence) or isinstance(prompt, str):  # str is a Sequence
+            elif isinstance(prompt, Sequence):
+                if not isinstance(val, Sequence):
                     raise ValidationError(
-                        f"Invalid type {type(val)}, perplexity should be a float if prompt is a str, and should be a sequence if prompt is a sequence"
+                        f"Invalid type {type(val)}, perplexity should be a sequence when prompt is a sequence"
                     )
                 if len(prompt) != len(val):
                     raise ValidationError("Length of the prompt and perplexity lists must match.")

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -206,12 +206,13 @@ def process_get_trustworthiness_score_kwargs(
     # checking validity/format of each input kwarg, each one might require a different format
     for key, val in kwargs_dict.items():
         if key == "perplexity":
-            if isinstance(val, float) or isinstance(val, int):
+            if val is None or isinstance(val, float) or isinstance(val, int):
                 if not isinstance(prompt, str):
                     raise ValidationError(
                         f"Invalid type {type(val)}, perplexity should be a float if prompt is a str, and should be a sequence if prompt is a sequence"
                     )
-                if not 0 <= val <= 1:
+                # TODO: should we raise warning if perplexity is None?
+                if val is not None and not 0 <= val <= 1:
                     raise ValidationError("Perplexity values must be between 0 and 1")
 
             elif isinstance(val, Sequence):
@@ -221,7 +222,7 @@ def process_get_trustworthiness_score_kwargs(
                     )
                 if len(prompt) != len(val):
                     raise ValidationError("Length of the prompt and perplexity lists must match.")
-                if not all(0 <= v <= 1 for v in val):
+                if not all(v is None or 0 <= v <= 1 for v in val):
                     raise ValidationError("Perplexity values must be between 0 and 1")
 
             else:

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -226,8 +226,15 @@ def process_response_and_kwargs(
                         raise ValidationError(
                             "Length of the response and perplexity lists must match."
                         )
-                    if not all(v is None or 0 <= v <= 1 for v in val):
-                        raise ValidationError("Perplexity values must be between 0 and 1")
+
+                    for v in val:
+                        if not (v is None or isinstance(v, float) or isinstance(v, int)):
+                            raise ValidationError(
+                                f"Invalid type {type(v)}, perplexity values must be a float"
+                            )
+
+                        if v is not None and not 0 <= v <= 1:
+                            raise ValidationError("Perplexity values must be between 0 and 1")
 
                 else:
                     raise ValidationError(

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -6,6 +6,7 @@ from cleanlab_studio.internal.constants import (
     TLM_MAX_TOKEN_RANGE,
     TLM_NUM_CANDIDATE_RESPONSES_RANGE,
     TLM_NUM_CONSISTENCY_SAMPLES_RANGE,
+    TLM_VALID_LOG_OPTIONS,
 )
 
 
@@ -177,4 +178,15 @@ def validate_tlm_options(options: Any) -> None:
             if not isinstance(val, bool):
                 raise ValidationError(
                     f"Invalid type {type(val)}, use_self_reflection must be a boolean"
+                )
+
+        elif option == "logs":
+            if not isinstance(val, list):
+                raise ValidationError(f"Invalid type {type(val)}, logs must be a list of strings.")
+
+            invalid_log_options = set(option["logs"]) - TLM_VALID_LOG_OPTIONS
+
+            if invalid_log_options:
+                raise ValidationError(
+                    f"Invalid options for logs: {invalid_log_options}. Valid options include: {TLM_VALID_LOG_OPTIONS}"
                 )

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, Optional, TypedDict, Literal, Union
-
+from cleanlab_studio.studio.trustworthy_language_model import TLMScore
 
 JSONDict = Dict[str, Any]
 
@@ -11,7 +11,7 @@ class SchemaOverride(TypedDict):
 
 TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
 
-TLMScoreResponse = Union[float, Dict[str, Any]]
+TLMScoreResponse = Union[float, TLMScore]
 
 
 class CleanlabSettingsDict(TypedDict):

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, TypedDict, Literal
+from typing import Any, Dict, Optional, TypedDict, Literal, Union
 
 
 JSONDict = Dict[str, Any]
@@ -10,6 +10,8 @@ class SchemaOverride(TypedDict):
 
 
 TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
+
+TLMScoreResponse = Union[float, Dict[str, Any]]
 
 
 class CleanlabSettingsDict(TypedDict):

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -1,5 +1,4 @@
-from typing import Any, Dict, Optional, TypedDict, Literal, Union
-from cleanlab_studio.studio.trustworthy_language_model import TLMScore
+from typing import Any, Dict, Optional, TypedDict, Literal
 
 JSONDict = Dict[str, Any]
 
@@ -10,8 +9,6 @@ class SchemaOverride(TypedDict):
 
 
 TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
-
-TLMScoreResponse = Union[float, TLMScore]
 
 
 class CleanlabSettingsDict(TypedDict):

--- a/cleanlab_studio/internal/types.py
+++ b/cleanlab_studio/internal/types.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional, TypedDict, Literal
 
+
 JSONDict = Dict[str, Any]
 
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -621,7 +621,7 @@ class TLMResponse(TypedDict):
 
     response: str
     trustworthiness_score: Optional[float]
-    log: Optional[dict]
+    log: Optional[Dict[str, Any]]
 
 
 class TLMOptions(TypedDict):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -384,7 +384,7 @@ class TLM:
         if self._return_logs:
             tlm_response["logs"] = response_json["logs"]
 
-        return tlm_response
+        return cast(TLMResponse, tlm_response)
 
     def get_trustworthiness_score(
         self,
@@ -410,6 +410,7 @@ class TLM:
                 If saving partial results is important, you can call this method on smaller batches of prompt-response pairs at a time
                 (and save intermediate results) or use the [`try_get_trustworthiness_score()`](#method-try_get_trustworthiness_score) method instead.
         """
+        # TODO: validate logprobs as well
         validate_tlm_prompt_response(prompt, response)
 
         if isinstance(prompt, str) and isinstance(response, str):
@@ -533,6 +534,7 @@ class TLM:
         Args:
             prompt: prompt for the TLM to evaluate
             response: response corresponding to the input prompt
+            logprobs: log probabilities associated with the given responses
             client_session: async HTTP session to use for TLM query. Defaults to None.
             timeout: timeout (in seconds) to run the prompt, defaults to None (no timeout)
             capture_exceptions: if should return None in place of the response for any errors

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -415,7 +415,11 @@ class TLM:
         validate_tlm_prompt_response(prompt, response)
         input_metadata = process_get_trustworthiness_score_kwargs(prompt, kwargs)
 
-        if isinstance(prompt, str) and isinstance(response, str):
+        if (
+            isinstance(prompt, str)
+            and isinstance(response, str)
+            and isinstance(input_metadata, Dict)
+        ):
             return cast(
                 TLMScoreResponse,
                 self._event_loop.run_until_complete(
@@ -471,7 +475,7 @@ class TLM:
         input_metadata = process_get_trustworthiness_score_kwargs(prompt, kwargs)
 
         return cast(
-            List[Optional[float]],
+            List[Optional[TLMScoreResponse]],
             self._event_loop.run_until_complete(
                 self._batch_get_trustworthiness_score(
                     prompt, response, input_metadata, capture_exceptions=True
@@ -506,7 +510,11 @@ class TLM:
         input_metadata = process_get_trustworthiness_score_kwargs(prompt, kwargs)
 
         async with aiohttp.ClientSession() as session:
-            if isinstance(prompt, str) and isinstance(response, str):
+            if (
+                isinstance(prompt, str)
+                and isinstance(response, str)
+                and isinstance(input_metadata, Dict)
+            ):
                 trustworthiness_score = await self._get_trustworthiness_score_async(
                     prompt,
                     response,

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -180,9 +180,9 @@ class TLM:
         )
 
         if capture_exceptions:
-            return cast(List[Optional[float]], tlm_responses)
+            return cast(List[Optional[TLMScoreResponse]], tlm_responses)
 
-        return cast(List[float], tlm_responses)
+        return cast(List[TLMScoreResponse], tlm_responses)
 
     async def _batch_async(
         self,
@@ -418,7 +418,7 @@ class TLM:
         if (
             isinstance(prompt, str)
             and isinstance(response, str)
-            and isinstance(input_metadata, Dict)
+            and isinstance(input_metadata, dict)
         ):
             return cast(
                 TLMScoreResponse,
@@ -472,7 +472,9 @@ class TLM:
                 use the [`get_trustworthiness_score()`](#method-get_trustworthiness_score) method instead.
         """
         validate_try_tlm_prompt_response(prompt, response)
-        input_metadata = process_get_trustworthiness_score_kwargs(prompt, kwargs)
+        input_metadata = cast(
+            List[Dict[str, Any]], process_get_trustworthiness_score_kwargs(prompt, kwargs)
+        )
 
         return cast(
             List[Optional[TLMScoreResponse]],
@@ -513,7 +515,7 @@ class TLM:
             if (
                 isinstance(prompt, str)
                 and isinstance(response, str)
-                and isinstance(input_metadata, Dict)
+                and isinstance(input_metadata, dict)
             ):
                 trustworthiness_score = await self._get_trustworthiness_score_async(
                     prompt,
@@ -523,10 +525,10 @@ class TLM:
                     timeout=self._timeout,
                     capture_exceptions=False,
                 )
-                return cast(float, trustworthiness_score)
+                return cast(TLMScoreResponse, trustworthiness_score)
 
             return cast(
-                List[float],
+                List[TLMScoreResponse],
                 await self._batch_get_trustworthiness_score(
                     prompt, response, input_metadata, capture_exceptions=False
                 ),
@@ -541,7 +543,7 @@ class TLM:
         timeout: Optional[float] = None,
         capture_exceptions: bool = False,
         batch_index: Optional[int] = None,
-    ) -> TLMScoreResponse:
+    ) -> Optional[TLMScoreResponse]:
         """Private asynchronous method to get trustworthiness score for prompt-response pairs.
 
         Args:

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import Coroutine, List, Optional, Union, cast, Sequence, Any, Dict, TYPE_CHECKING
+from typing import Coroutine, List, Optional, Union, cast, Sequence, Any, Dict
 from tqdm.asyncio import tqdm_asyncio
 
 import aiohttp
@@ -26,14 +26,12 @@ from cleanlab_studio.internal.tlm.validation import (
     validate_tlm_options,
     process_response_and_kwargs,
 )
+from cleanlab_studio.internal.types import TLMQualityPreset
 from cleanlab_studio.errors import ValidationError
 from cleanlab_studio.internal.constants import (
     _VALID_TLM_QUALITY_PRESETS,
     _TLM_MAX_RETRIES,
 )
-
-if TYPE_CHECKING:
-    from cleanlab_studio.internal.types import TLMQualityPreset, TLMScoreResponse
 
 
 class TLM:
@@ -611,6 +609,9 @@ class TLMScore(TypedDict):
 
     trustworthiness_score: Optional[float]
     log: Optional[Dict[str, Any]]
+
+
+TLMScoreResponse = Union[float, TLMScore]
 
 
 class TLMOptions(TypedDict):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -186,7 +186,7 @@ class TLM:
 
     async def _batch_async(
         self,
-        tlm_coroutines: Sequence[Coroutine[None, None, Union[TLMResponse, float, None]]],
+        tlm_coroutines: Sequence[Coroutine[None, None, Union[TLMResponse, TLMScoreResponse, None]]],
         batch_timeout: Optional[float] = None,
     ) -> Sequence[Union[TLMResponse, float, None]]:
         """Runs batch of TLM queries.
@@ -433,6 +433,12 @@ class TLM:
                 ),
             )
 
+        assert (
+            isinstance(prompt, Sequence)
+            and isinstance(prompt, Sequence)
+            and isinstance(input_metadata, list)
+        )
+
         return cast(
             List[TLMScoreResponse],
             self._event_loop.run_until_complete(
@@ -472,15 +478,16 @@ class TLM:
                 use the [`get_trustworthiness_score()`](#method-get_trustworthiness_score) method instead.
         """
         validate_try_tlm_prompt_response(prompt, response)
-        input_metadata = cast(
-            List[Dict[str, Any]], process_get_trustworthiness_score_kwargs(prompt, kwargs)
-        )
+        input_metadata = process_get_trustworthiness_score_kwargs(prompt, kwargs)
 
         return cast(
             List[Optional[TLMScoreResponse]],
             self._event_loop.run_until_complete(
                 self._batch_get_trustworthiness_score(
-                    prompt, response, input_metadata, capture_exceptions=True
+                    prompt,
+                    response,
+                    cast(List[Dict[str, Any]], input_metadata),
+                    capture_exceptions=True,
                 )
             ),
         )
@@ -526,6 +533,12 @@ class TLM:
                     capture_exceptions=False,
                 )
                 return cast(TLMScoreResponse, trustworthiness_score)
+
+            assert (
+                isinstance(prompt, Sequence)
+                and isinstance(prompt, Sequence)
+                and isinstance(input_metadata, list)
+            )
 
             return cast(
                 List[TLMScoreResponse],

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -417,7 +417,7 @@ class TLM:
 
         if isinstance(prompt, str) and isinstance(response, str):
             return cast(
-                float,
+                TLMScoreResponse,
                 self._event_loop.run_until_complete(
                     self._get_trustworthiness_score_async(
                         prompt,
@@ -430,7 +430,7 @@ class TLM:
             )
 
         return cast(
-            List[float],
+            List[TLMScoreResponse],
             self._event_loop.run_until_complete(
                 self._batch_get_trustworthiness_score(
                     prompt, response, input_metadata, capture_exceptions=False

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -134,7 +134,7 @@ class TLM:
     async def _batch_get_trustworthiness_score(
         self,
         prompts: Sequence[str],
-        responses: Sequence[str],
+        responses: Sequence[Dict[str, Any]],
         capture_exceptions: bool = False,
     ) -> Union[List[TLMScoreResponse], List[Optional[TLMScoreResponse]]]:
         """Run batch of TLM get trustworthiness score.
@@ -411,9 +411,7 @@ class TLM:
         validate_tlm_prompt_response(prompt, response)
         processed_response = process_response_and_kwargs(response, kwargs)
 
-        if isinstance(prompt, str) and (
-            isinstance(processed_response, str) or isinstance(processed_response, dict)
-        ):
+        if isinstance(prompt, str) and isinstance(processed_response, dict):
             return cast(
                 TLMScoreResponse,
                 self._event_loop.run_until_complete(
@@ -468,6 +466,8 @@ class TLM:
         """
         validate_try_tlm_prompt_response(prompt, response)
         processed_response = process_response_and_kwargs(response, kwargs)
+
+        assert isinstance(processed_response, list)
 
         return cast(
             List[Optional[TLMScoreResponse]],
@@ -529,7 +529,7 @@ class TLM:
     async def _get_trustworthiness_score_async(
         self,
         prompt: str,
-        response: str,
+        response: Dict[str, Any],
         client_session: Optional[aiohttp.ClientSession] = None,
         timeout: Optional[float] = None,
         capture_exceptions: bool = False,

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -450,7 +450,6 @@ class TLM:
         Args:
             prompt (Sequence[str]): list of prompts for the TLM to evaluate
             response (Sequence[str]): list of existing responses corresponding to the input prompts (from any LLM or human-written)
-            logprobs (Sequence[float]): list of log probabilities associated with the given responses
         Returns:
             List[float]: list of floats corresponding to the TLM's trustworthiness score.
                 The score quantifies how confident TLM is that the given response is good for the given prompt.
@@ -477,7 +476,7 @@ class TLM:
         self,
         prompt: Union[str, Sequence[str]],
         response: Union[str, Sequence[str]],
-        logprobs: Optional[Union[float, Sequence[float]]] = None,
+        **kwargs: Any,
     ) -> Union[TLMScoreResponse, List[TLMScoreResponse]]:
         """Asynchronously gets trustworthiness score for prompt-response pairs.
         This method is similar to the [`get_trustworthiness_score()`](#method-get_trustworthiness_score) method but operates asynchronously,
@@ -490,14 +489,13 @@ class TLM:
         Args:
             prompt (str | Sequence[str]): prompt (or list of prompts) for the TLM to evaluate
             response (str | Sequence[str]): response (or list of responses) corresponding to the input prompts
-            logprobs (Sequence[float]): list of log probabilities associated with the given responses
         Returns:
             float | List[float]: float or list of floats (if multiple prompt-responses were provided) corresponding
                 to the TLM's trustworthiness score.
                 The score quantifies how confident TLM is that the given response is good for the given prompt.
                 This method will raise an exception if any errors occur or if you hit a timeout (given a timeout is specified).
         """
-        # TODO: add validation for logprobs
+        # TODO: add validation for kwargs
         validate_tlm_prompt_response(prompt, response)
 
         async with aiohttp.ClientSession() as session:

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import Coroutine, List, Optional, Union, cast, Sequence, Any, Dict
+from typing import Coroutine, List, Optional, Union, cast, Sequence, Any, Dict, TYPE_CHECKING
 from tqdm.asyncio import tqdm_asyncio
 
 import aiohttp
@@ -26,12 +26,14 @@ from cleanlab_studio.internal.tlm.validation import (
     validate_tlm_options,
     process_response_and_kwargs,
 )
-from cleanlab_studio.internal.types import TLMQualityPreset, TLMScoreResponse
 from cleanlab_studio.errors import ValidationError
 from cleanlab_studio.internal.constants import (
     _VALID_TLM_QUALITY_PRESETS,
     _TLM_MAX_RETRIES,
 )
+
+if TYPE_CHECKING:
+    from cleanlab_studio.internal.types import TLMQualityPreset, TLMScoreResponse
 
 
 class TLM:
@@ -584,7 +586,7 @@ class TLM:
 
 
 class TLMResponse(TypedDict):
-    """A typed dict containing the response and trustworthiness score from the Trustworthy Language Model.
+    """A typed dict containing the response, trustworthiness score and additional logs from the Trustworthy Language Model.
 
     Attributes:
         response (str): text response from the Trustworthy Language Model.
@@ -597,6 +599,16 @@ class TLMResponse(TypedDict):
     """
 
     response: str
+    trustworthiness_score: Optional[float]
+    log: Optional[Dict[str, Any]]
+
+
+class TLMScore(TypedDict):
+    """A typed dict containing the trustworthiness score and additional logs from the Trustworthy Language Model.
+
+    This dictionary is similar to TLMResponse, except it does not contain the response key.
+    """
+
     trustworthiness_score: Optional[float]
     log: Optional[Dict[str, Any]]
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -65,7 +65,7 @@ class TLM:
         self._return_log = False
         if options is not None:
             validate_tlm_options(options)
-            if "log" in options.keys():  # TODO: figure out check
+            if "log" in options.keys():
                 self._return_log = True
 
         if timeout is not None and not (isinstance(timeout, int) or isinstance(timeout, float)):


### PR DESCRIPTION
- Adds a new TLMOption, `log`, which allows users to specify what additional logs/metadata they want returned.
  If logs is specified (by default it will be `None`):
  - `tlm.prompt()` will return the same dictionary with an additional `log` key-value pair
  - `tlm.get_trustworthiness_score` will return a dictionary (with `trustworthiness_score` and `log` as keys) instead of float

- Adds an new optional keyword argument to `tlm.get_trustworthiness_score` named `perplexity` which allows users to pass in perplexity scores (from their own LLM, or anywhere else) to consider as part of the scoring computation


### Sample workflow:

```python
tlm_prompt = studio.TLM("base", options={ "log": ["perplexity"]})
res = tlm_prompt.prompt(prompt)
res 

>> {"response": ..., trustworthiness_score": ..., "log": {"perplexity": 0.5}}
```

We see that the results above has an extra key `log` which gives us the metadata, that perplexity can now be used in the `get_trustworthiness_score` method as such:

```python
tlm_score = studio.TLM()
tlm_score.get_trustworthiness_score(prompt, res["response"], perplexity=res["log"]["perplexity"])
```

Sample batch prompt usage:
```python
prompt = ["What is 1+1?", "What is the colour of water?"]

tlm_prompt = studio.TLM("base", options={"log": ["perplexity"]})
res = tlm_prompt.prompt(prompt)
res

tlm_score = studio.TLM()
tlm_score.get_trustworthiness_score(prompt, [r["response"] for r in res], perplexity=[r["log"]["perplexity"] for r in res])
```