### PR TITLE
add api methods for deploying model

### DIFF
--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -137,3 +137,7 @@ class InvalidSchemaTypeError(ValueError):
 
 class InvalidProjectConfiguration(HandledError):
     pass
+
+
+class DeploymentError(HandledError):
+    pass

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -520,6 +520,32 @@ def poll_ingestion_progress(api_key: str, upload_id: str, description: str) -> s
     return str(dataset_id)
 
 
+def deploy_model(api_key: str, cleanset_id: str, model_name: str) -> str:
+    """Deploys model and returns model ID."""
+    check_uuid_well_formed(cleanset_id, "cleanset ID")
+    res = requests.post(
+        model_base_url,
+        headers=_construct_headers(api_key),
+        json=dict(cleanset_id=cleanset_id, deployment_name=model_name),
+    )
+
+    handle_api_error(res)
+    model_id: str = res.json()["id"]
+    return model_id
+
+
+def get_deployment_status(api_key: str, model_id: str) -> JSONDict:
+    """Gets status of model deployment."""
+    check_uuid_well_formed(model_id, "model ID")
+    res = requests.get(
+        f"{model_base_url}/{model_id}",
+        headers=_construct_headers(api_key),
+    )
+    handle_api_error(res)
+    deployment: JSONDict = res.json()
+    return str(deployment["status"])
+
+
 def upload_predict_batch(api_key: str, model_id: str, batch: io.StringIO) -> str:
     """Uploads prediction batch and returns query ID."""
     check_uuid_well_formed(model_id, "model ID")

--- a/cleanlab_studio/internal/deploy_helpers.py
+++ b/cleanlab_studio/internal/deploy_helpers.py
@@ -1,0 +1,44 @@
+import enum
+import itertools
+import time
+from typing import Optional
+
+from cleanlab_studio.errors import DeploymentError
+from cleanlab_studio.internal.api import api
+from tqdm import tqdm
+
+
+class DeploymentStatus(enum.Enum):
+    INITIALIZING = "INITIALIZING"
+    TRAINING = "TRAINING"
+    TRAINED = "TRAINED"
+    FAILED = "FAILED"
+
+
+def poll_deployment_status(api_key: str, model_id: str, timeout: Optional[float] = None) -> None:
+    start_time = time.time()
+    res = api.get_deployment_status(api_key, model_id)
+    spinner = itertools.cycle("|/-\\")
+
+    with tqdm(total=1, desc="Deploying Model: \\", bar_format="{desc}") as pbar:
+        while (
+            not res == DeploymentStatus.TRAINED.value and not res == DeploymentStatus.FAILED.value
+        ):
+            pbar.set_description_str(f"Deploying Model: {next(spinner)}")
+            if timeout is not None and time.time() - start_time > timeout:
+                raise TimeoutError("Model not ready before timeout")
+
+            for _ in range(50):
+                time.sleep(0.1)
+                pbar.set_description_str(f"Deploying Model: {next(spinner)}")
+
+            res = api.get_deployment_status(api_key, model_id)
+
+            if res == DeploymentStatus.TRAINED.value:
+                pbar.set_description_str("Model trained successfully")
+                pbar.update(pbar.total - pbar.n)
+                return
+
+            if res == DeploymentStatus.FAILED.value:
+                pbar.set_description_str("Model training failed")
+                raise DeploymentError(f"Model training failed for {model_id}")

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -13,7 +13,7 @@ import pandas as pd
 from . import inference
 from . import trustworthy_language_model
 from cleanlab_studio.errors import CleansetError
-from cleanlab_studio.internal import clean_helpers, upload_helpers
+from cleanlab_studio.internal import clean_helpers, deploy_helpers, upload_helpers
 from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.util import (
     init_dataset_source,
@@ -317,6 +317,29 @@ class Studio:
         """
         api.delete_project(self._api_key, project_id)
         print(f"Successfully deleted project: {project_id}")
+
+    def deploy_model(self, cleanset_id: str, model_name: str) -> str:
+        """
+        Trains and deploys a model with an improved dataset created by applying any corrections you've made to your cleanset in Cleanlab Studio.
+
+        Args:
+            cleanset_id: ID of cleanset to deploy model for.
+            model_name: Name for resulting model.
+        """
+        return api.deploy_model(self._api_key, cleanset_id, model_name)
+
+    def wait_until_model_ready(self, model_id: str, timeout: Optional[float] = None) -> str:
+        """Blocks until a model is ready or the timeout is reached.
+
+        Args:
+            model_id (str): ID of model to check status for.
+            timeout (Optional[float], optional): timeout for polling, in seconds. Defaults to None.
+
+        Raises:
+            TimeoutError: if model is not ready by end of timeout
+            DeploymentError: if model errored while training
+        """
+        deploy_helpers.poll_deployment_status(self._api_key, model_id, timeout)
 
     def get_model(self, model_id: str) -> inference.Model:
         """


### PR DESCRIPTION
Adds methods to `deploy_model()` and `wait_until_model_ready()` through Python API. These methods are required to enable us to add regression testing for model deployment.