### PR TITLE
Mypy fix - update np.float_ to np.float64

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -299,7 +299,7 @@ def download_cleanlab_columns(
 
 def download_array(
     api_key: str, cleanset_id: str, name: str
-) -> Union[npt.NDArray[np.float_], pd.DataFrame]:
+) -> Union[npt.NDArray[np.float64], pd.DataFrame]:
     check_uuid_well_formed(cleanset_id, "cleanset ID")
     res = requests.get(
         cli_base_url + f"/cleansets/{cleanset_id}/{name}",
@@ -309,7 +309,7 @@ def download_array(
     res_json: JSONDict = res.json()
     if res_json["success"]:
         if res_json["array_type"] == "numpy":
-            np_data: npt.NDArray[np.float_] = np.array(res_json[name])
+            np_data: npt.NDArray[np.float64] = np.array(res_json[name])
             return np_data
         pd_data: pd.DataFrame = pd.read_json(StringIO(res_json[name]), orient="records")
         return pd_data

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -356,7 +356,7 @@ class Studio:
         If you want to work with predicted probabilities for an image project, the recommended workflow is to download probabilities with the option `keep_id=True`, and then do a join with the original dataset on the ID column.
         Alternatively, you can follow the steps [here](/reference/python/studio#method-download_embeddings), and filter out the rows that were not analyzed. The filtered dataset will then have rows that align with the predicted probabilities DataFrame.
         """
-        pred_probs: Union[npt.NDArray[np.float_], pd.DataFrame] = api.download_array(
+        pred_probs: Union[npt.NDArray[np.float64], pd.DataFrame] = api.download_array(
             self._api_key, cleanset_id, "pred_probs"
         )
         if not isinstance(pred_probs, pd.DataFrame):
@@ -373,7 +373,7 @@ class Studio:
     def download_embeddings(
         self,
         cleanset_id: str,
-    ) -> npt.NDArray[np.float_]:
+    ) -> npt.NDArray[np.float64]:
         """
         Downloads feature embeddings for a cleanset (available only for text and image projects).
         These are numeric vectors produced via neural network representations of each data point in your dataset.


### PR DESCRIPTION
I'm updating this line to have more a modern and explicit type annotation for numpy floats. `np.float_` is removed in later NumPy versions