### PR TITLE
Remove .pre-commit-hooks.yaml file

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,0 @@
-- id: black
-  name: black
-  description: "Black: The uncompromising Python code formatter"
-  entry: black
-  language: python
-  minimum_pre_commit_version: 2.9.2
-  require_serial: true
-  types_or: [python, pyi]


### PR DESCRIPTION
### Description

This file `.pre-commit-hooks.yaml` is intended to be used for repos that publish pre-commit hooks. That is not the case for this repo.

### Motivation and Context

Having both this file and `.pre-commit-hooks.yaml` can mislead developers about which file they should update.