### PR TITLE
Add gpt-4o as TLM model option

### DIFF
--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -3,7 +3,13 @@ from typing import List, Tuple
 # TLM constants
 # prepend constants with _ so that they don't show up in help.cleanlab.ai docs
 _VALID_TLM_QUALITY_PRESETS: List[str] = ["best", "high", "medium", "low", "base"]
-_VALID_TLM_MODELS: List[str] = ["gpt-3.5-turbo-16k", "gpt-4", "claude-3-haiku", "claude-3-sonnet"]
+_VALID_TLM_MODELS: List[str] = [
+    "gpt-3.5-turbo-16k",
+    "gpt-4",
+    "gpt-4o",
+    "claude-3-haiku",
+    "claude-3-sonnet",
+]
 _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 TLM_MAX_TOKEN_RANGE: Tuple[int, int] = (64, 512)  # (min, max)
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: Tuple[int, int] = (1, 20)  # (min, max)

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -581,7 +581,7 @@ class TLMOptions(TypedDict):
 
     Args:
         model (str, default = "gpt-3.5-turbo-16k"): underlying LLM to use (better models will yield better results).
-        Models currently supported include "gpt-3.5-turbo-16k", "gpt-4".
+        Models currently supported include "gpt-3.5-turbo-16k", "gpt-4", "gpt-4o".
 
         max_tokens (int, default = 512): the maximum number of tokens to generate in the TLM response.
         This number will impact the maximum number of tokens you will see in the output response, and also the number of tokens


### PR DESCRIPTION
Adds `gpt-4o` TLM model options, do not merge until backend is ready.