### PR TITLE
Hotfix - check that error is dict before calling .get()

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -80,7 +80,11 @@ def handle_api_error_from_json(res_json: JSONDict, status_code: Optional[int] = 
 
     if res_json.get("error", None) is not None:
         error = res_json["error"]
-        if status_code == 422 and error.get("code", None) == "UNSUPPORTED_PROJECT_CONFIGURATION":
+        if (
+            status_code == 422
+            and isinstance(error, dict)
+            and error.get("code", None) == "UNSUPPORTED_PROJECT_CONFIGURATION"
+        ):
             raise InvalidProjectConfiguration(error["description"])
         raise APIError(res_json["error"])
 


### PR DESCRIPTION
We have some handled api errors in the backend server that return an error string instead of a dictionary with the `code` and `description` properties. ex: `abort(422, "Download failed...")`. I'm adding a check to avoid the following error and instead print the actual error string: `AttributeError: 'str' object has no attribute 'get'` . Ideally our backend responses would have a more rigorous format, but adding this lightweight check now will avoid triggering an unhandled exception and show the actual error message.