### PR TITLE
move most TLM documentation off of the main Studio docs page

### DIFF
--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -427,42 +427,9 @@ class Studio:
         timeout: Optional[float] = None,
         verbose: Optional[bool] = None,
     ) -> trustworthy_language_model.TLM:
-        """Instantiates a configured Trustworthy Language Model (TLM) instance.
-
-        The TLM object can be used as a drop-in replacement for an LLM, or, for estimating trustworthiness scores for arbitrary text prompt/response pairs, and more (see the [TLM documentation](../trustworthy_language_model#class-tlm)).
-
-        For advanced use, TLM offers configuration options. The documentation below summarizes these options, and more details are explained in the [TLM tutorial](/tutorials/tlm).
-
-        Args:
-            quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
-                TLMQualityPreset is a string specifying one of the supported presets, including "best", "high", "medium", "low", "base".
-
-                The "best" and "high" presets return improved LLM responses,
-                with "best" also returning more reliable trustworthiness scores than "high".
-                The "medium" and "low" presets return standard LLM responses along with associated trustworthiness scores,
-                with "medium" producing more reliable trustworthiness scores than low.
-                The "base" preset will not return any trustworthiness score, just a standard LLM response, and is similar to directly using your favorite LLM API.
-
-                Higher presets have increased runtime and cost (and may internally consume more tokens).
-                Reduce your preset if you see token-limit errors.
-                Details about each present are in the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
-                Avoid using "best" or "high" presets if you primarily want to get trustworthiness scores, and are less concerned with improving LLM responses.
-                These presets have higher runtime/cost and are optimized to return more accurate LLM outputs, but not necessarily more reliable trustworthiness scores.
-
-            options (TLMOptions, optional): a typed dict of advanced configuration options.
-            Avaialable options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
-            For more details about the options, see the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
-            If specified, these override any settings from the choice of `quality_preset`.
-
-            timeout (float, optional): timeout (in seconds) to apply to each TLM prompt.
-            If a batch of data is passed in, the timeout will be applied to each individual item in the batch.
-            If a result is not produced within the timeout, a TimeoutError will be raised. Defaults to None, which does not apply a timeout.
-
-            verbose (bool, optional): whether to print outputs during execution, i.e., whether to show a progress bar when TLM is prompted with batches of data.
-            If None, this will be determined automatically based on whether the code is running in an interactive environment such as a Jupyter notebook.
-
-        Returns:
-            TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
+        """
+        For more details, see the documentation at:
+        [cleanlab_studio.studio.trustworthy_language_model.TLM](http://localhost:3000/reference/python/trustworthy_language_model/#method-__init__)
         """
         return trustworthy_language_model.TLM(
             self._api_key, quality_preset, options=options, timeout=timeout, verbose=verbose

--- a/cleanlab_studio/studio/studio.py
+++ b/cleanlab_studio/studio/studio.py
@@ -428,8 +428,9 @@ class Studio:
         verbose: Optional[bool] = None,
     ) -> trustworthy_language_model.TLM:
         """
-        For more details, see the documentation at:
-        [cleanlab_studio.studio.trustworthy_language_model.TLM](http://localhost:3000/reference/python/trustworthy_language_model/#method-__init__)
+        Instantiate a Trustworthy Language Model (TLM).
+        For more details, see the documentation of:
+        [cleanlab_studio.studio.trustworthy_language_model.TLM](../trustworthy_language_model/#class-tlm)
         """
         return trustworthy_language_model.TLM(
             self._api_key, quality_preset, options=options, timeout=timeout, verbose=verbose

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -35,10 +35,47 @@ from cleanlab_studio.internal.constants import (
 
 class TLM:
     """Represents a Trustworthy Language Model (TLM) instance, which is bound to a Cleanlab Studio account.
+    
+    The TLM object can be used as a drop-in replacement for an LLM, or, for estimating trustworthiness scores for arbitrary text prompt/response pairs.
+
+    For advanced use, TLM offers configuration options. The documentation below summarizes these options, and more details are explained in the [TLM tutorial](/tutorials/tlm).
 
     ** The TLM object is not meant to be constructed directly.** Instead, use the [`Studio.TLM()`](../studio/#method-tlm)
     method to configure and instantiate a TLM object.
     After you've instantiated the TLM object using [`Studio.TLM()`](../studio/#method-tlm), you can use the instance methods documented on this page.
+
+    Args:
+        api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
+
+        quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
+            TLMQualityPreset is a string specifying one of the supported presets, including "best", "high", "medium", "low", "base".
+
+            The "best" and "high" presets return improved LLM responses,
+            with "best" also returning more reliable trustworthiness scores than "high".
+            The "medium" and "low" presets return standard LLM responses along with associated trustworthiness scores,
+            with "medium" producing more reliable trustworthiness scores than low.
+            The "base" preset will not return any trustworthiness score, just a standard LLM response, and is similar to directly using your favorite LLM API.
+
+            Higher presets have increased runtime and cost (and may internally consume more tokens).
+            Reduce your preset if you see token-limit errors.
+            Details about each present are in the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
+            Avoid using "best" or "high" presets if you primarily want to get trustworthiness scores, and are less concerned with improving LLM responses.
+            These presets have higher runtime/cost and are optimized to return more accurate LLM outputs, but not necessarily more reliable trustworthiness scores.
+
+        options (TLMOptions, optional): a typed dict of advanced configuration options.
+        Avaialable options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
+        For more details about the options, see the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
+        If specified, these override any settings from the choice of `quality_preset`.
+
+        timeout (float, optional): timeout (in seconds) to apply to each TLM prompt.
+        If a batch of data is passed in, the timeout will be applied to each individual item in the batch.
+        If a result is not produced within the timeout, a TimeoutError will be raised. Defaults to None, which does not apply a timeout.
+
+        verbose (bool, optional): whether to print outputs during execution, i.e., whether to show a progress bar when TLM is prompted with batches of data.
+        If None, this will be determined automatically based on whether the code is running in an interactive environment such as a Jupyter notebook.
+
+    Returns:
+        TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
     """
 
     def __init__(
@@ -50,47 +87,8 @@ class TLM:
         timeout: Optional[float] = None,
         verbose: Optional[bool] = None,
     ) -> None:
-        """
-        Use `Studio.TLM()` instead of this method to initialize a TLM.
-
-        Instantiates a configured Trustworthy Language Model (TLM) instance.
-
-        The TLM object can be used as a drop-in replacement for an LLM, or, for estimating trustworthiness scores for arbitrary text prompt/response pairs, and more (see the [TLM documentation](../trustworthy_language_model#class-tlm)).
-
-        For advanced use, TLM offers configuration options. The documentation below summarizes these options, and more details are explained in the [TLM tutorial](/tutorials/tlm).
-
-        Args:
-            api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
-
-            quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
-                TLMQualityPreset is a string specifying one of the supported presets, including "best", "high", "medium", "low", "base".
-
-                The "best" and "high" presets return improved LLM responses,
-                with "best" also returning more reliable trustworthiness scores than "high".
-                The "medium" and "low" presets return standard LLM responses along with associated trustworthiness scores,
-                with "medium" producing more reliable trustworthiness scores than low.
-                The "base" preset will not return any trustworthiness score, just a standard LLM response, and is similar to directly using your favorite LLM API.
-
-                Higher presets have increased runtime and cost (and may internally consume more tokens).
-                Reduce your preset if you see token-limit errors.
-                Details about each present are in the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
-                Avoid using "best" or "high" presets if you primarily want to get trustworthiness scores, and are less concerned with improving LLM responses.
-                These presets have higher runtime/cost and are optimized to return more accurate LLM outputs, but not necessarily more reliable trustworthiness scores.
-
-            options (TLMOptions, optional): a typed dict of advanced configuration options.
-            Avaialable options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
-            For more details about the options, see the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
-            If specified, these override any settings from the choice of `quality_preset`.
-
-            timeout (float, optional): timeout (in seconds) to apply to each TLM prompt.
-            If a batch of data is passed in, the timeout will be applied to each individual item in the batch.
-            If a result is not produced within the timeout, a TimeoutError will be raised. Defaults to None, which does not apply a timeout.
-
-            verbose (bool, optional): whether to print outputs during execution, i.e., whether to show a progress bar when TLM is prompted with batches of data.
-            If None, this will be determined automatically based on whether the code is running in an interactive environment such as a Jupyter notebook.
-
-        Returns:
-            TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
+        """Use `Studio.TLM()` instead of this method to initialize a TLM.
+        lazydocs: ignore
         """
         self._api_key = api_key
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -50,9 +50,47 @@ class TLM:
         timeout: Optional[float] = None,
         verbose: Optional[bool] = None,
     ) -> None:
-        """Use `Studio.TLM()` instead of this method to initialize a TLM.
+        """
+        Use `Studio.TLM()` instead of this method to initialize a TLM.
 
-        lazydocs: ignore
+        Instantiates a configured Trustworthy Language Model (TLM) instance.
+
+        The TLM object can be used as a drop-in replacement for an LLM, or, for estimating trustworthiness scores for arbitrary text prompt/response pairs, and more (see the [TLM documentation](../trustworthy_language_model#class-tlm)).
+
+        For advanced use, TLM offers configuration options. The documentation below summarizes these options, and more details are explained in the [TLM tutorial](/tutorials/tlm).
+
+        Args:
+            api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
+            
+            quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
+                TLMQualityPreset is a string specifying one of the supported presets, including "best", "high", "medium", "low", "base".
+
+                The "best" and "high" presets return improved LLM responses,
+                with "best" also returning more reliable trustworthiness scores than "high".
+                The "medium" and "low" presets return standard LLM responses along with associated trustworthiness scores,
+                with "medium" producing more reliable trustworthiness scores than low.
+                The "base" preset will not return any trustworthiness score, just a standard LLM response, and is similar to directly using your favorite LLM API.
+
+                Higher presets have increased runtime and cost (and may internally consume more tokens).
+                Reduce your preset if you see token-limit errors.
+                Details about each present are in the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
+                Avoid using "best" or "high" presets if you primarily want to get trustworthiness scores, and are less concerned with improving LLM responses.
+                These presets have higher runtime/cost and are optimized to return more accurate LLM outputs, but not necessarily more reliable trustworthiness scores.
+
+            options (TLMOptions, optional): a typed dict of advanced configuration options.
+            Avaialable options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
+            For more details about the options, see the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
+            If specified, these override any settings from the choice of `quality_preset`.
+
+            timeout (float, optional): timeout (in seconds) to apply to each TLM prompt.
+            If a batch of data is passed in, the timeout will be applied to each individual item in the batch.
+            If a result is not produced within the timeout, a TimeoutError will be raised. Defaults to None, which does not apply a timeout.
+
+            verbose (bool, optional): whether to print outputs during execution, i.e., whether to show a progress bar when TLM is prompted with batches of data.
+            If None, this will be determined automatically based on whether the code is running in an interactive environment such as a Jupyter notebook.
+
+        Returns:
+            TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
         """
         self._api_key = api_key
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -65,7 +65,7 @@ Possible arguments for `Studio.TLM()` are documented below.
 
         options (TLMOptions, optional): a typed dict of advanced configuration options.
         Available options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
-        For more details about the options, see the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
+        For more details about the options, see the documentation for [TLMOptions](#class-tlmoptions).
         If specified, these override any settings from the choice of `quality_preset`.
 
         timeout (float, optional): timeout (in seconds) to apply to each TLM prompt.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -34,7 +34,8 @@ from cleanlab_studio.internal.constants import (
 
 
 class TLM:
-    """Represents a Trustworthy Language Model (TLM) instance, which is bound to a Cleanlab Studio account.
+    """
+    Represents a Trustworthy Language Model (TLM) instance, which is bound to a Cleanlab Studio account.
 
     The TLM object can be used as a drop-in replacement for an LLM, or, for estimating trustworthiness scores for arbitrary text prompt/response pairs.
 
@@ -42,14 +43,12 @@ class TLM:
 
     ** The TLM object is not meant to be constructed directly.** Instead, use the [`Studio.TLM()`](../studio/#method-tlm)
     method to configure and instantiate a TLM object.
-    After you've instantiated the TLM object using [`Studio.TLM()`](../studio/#method-tlm), you can use the instance methods documented on this page.
-Possible arguments for `Studio.TLM()` are documented below.
+    After you've instantiated the TLM object using [`Studio.TLM()`](../studio/#method-tlm), you can use the instance methods documented on this page. Possible arguments for `Studio.TLM()` are documented below.
 
     Args:
         api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
 
-        quality_preset (TLMQualityPreset, default = "medium"): An optional preset configuration to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
-            TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base".
+        quality_preset (TLMQualityPreset, default = "medium"): An optional preset configuration to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs. TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base".
 
             The "best" and "high" presets return improved LLM responses,
             with "best" also returning more reliable trustworthiness scores than "high".

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -35,7 +35,7 @@ from cleanlab_studio.internal.constants import (
 
 class TLM:
     """Represents a Trustworthy Language Model (TLM) instance, which is bound to a Cleanlab Studio account.
-    
+
     The TLM object can be used as a drop-in replacement for an LLM, or, for estimating trustworthiness scores for arbitrary text prompt/response pairs.
 
     For advanced use, TLM offers configuration options. The documentation below summarizes these options, and more details are explained in the [TLM tutorial](/tutorials/tlm).

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -49,7 +49,7 @@ Possible arguments for `Studio.TLM()` are documented below.
         api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
 
         quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
-            TLMQualityPreset is a string specifying one of the supported presets, including "best", "high", "medium", "low", "base".
+            TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base" (default is "medium").
 
             The "best" and "high" presets return improved LLM responses,
             with "best" also returning more reliable trustworthiness scores than "high".

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -59,7 +59,7 @@ Possible arguments for `Studio.TLM()` are documented below.
 
             Higher presets have increased runtime and cost (and may internally consume more tokens).
             Reduce your preset if you see token-limit errors.
-            Details about each present are in the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
+            Details about each present are in the documentation for [TLMOptions](#class-tlmoptions).
             Avoid using "best" or "high" presets if you primarily want to get trustworthiness scores, and are less concerned with improving LLM responses.
             These presets have higher runtime/cost and are optimized to return more accurate LLM outputs, but not necessarily more reliable trustworthiness scores.
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -64,7 +64,7 @@ Possible arguments for `Studio.TLM()` are documented below.
             These presets have higher runtime/cost and are optimized to return more accurate LLM outputs, but not necessarily more reliable trustworthiness scores.
 
         options (TLMOptions, optional): a typed dict of advanced configuration options.
-        Avaialable options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
+        Available options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection".
         For more details about the options, see the documentation for [TLMOptions](../trustworthy_language_model#class-tlmoptions).
         If specified, these override any settings from the choice of `quality_preset`.
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -74,9 +74,6 @@ Possible arguments for `Studio.TLM()` are documented below.
 
         verbose (bool, optional): whether to print outputs during execution, i.e., whether to show a progress bar when TLM is prompted with batches of data.
         If None, this will be determined automatically based on whether the code is running in an interactive environment such as a Jupyter notebook.
-
-    Returns:
-        TLM: the [Trustworthy Language Model](../trustworthy_language_model#class-tlm) object
     """
 
     def __init__(

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -48,8 +48,8 @@ Possible arguments for `Studio.TLM()` are documented below.
     Args:
         api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
 
-        quality_preset (TLMQualityPreset, optional): A pre-configured preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
-            TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base" (default is "medium").
+        quality_preset (TLMQualityPreset, default = "medium"): An optional preset configuration to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
+            TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base".
 
             The "best" and "high" presets return improved LLM responses,
             with "best" also returning more reliable trustworthiness scores than "high".

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -61,7 +61,7 @@ class TLM:
 
         Args:
             api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
-            
+
             quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
                 TLMQualityPreset is a string specifying one of the supported presets, including "best", "high", "medium", "low", "base".
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -48,7 +48,7 @@ Possible arguments for `Studio.TLM()` are documented below.
     Args:
         api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
 
-        quality_preset (TLMQualityPreset): An optional preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
+        quality_preset (TLMQualityPreset, optional): A pre-configured preset to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs.
             TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base" (default is "medium").
 
             The "best" and "high" presets return improved LLM responses,

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -43,6 +43,7 @@ class TLM:
     ** The TLM object is not meant to be constructed directly.** Instead, use the [`Studio.TLM()`](../studio/#method-tlm)
     method to configure and instantiate a TLM object.
     After you've instantiated the TLM object using [`Studio.TLM()`](../studio/#method-tlm), you can use the instance methods documented on this page.
+Possible arguments for `Studio.TLM()` are documented below.
 
     Args:
         api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.


### PR DESCRIPTION
For https://github.com/cleanlab/cleanlab-studio-docs/issues/500
<img width="1208" alt="Screenshot 2024-07-16 at 10 55 12 AM" src="https://github.com/user-attachments/assets/37483d2b-4b91-45b7-8cc2-e15a405bd80e">
<img width="1189" alt="Screenshot 2024-07-16 at 10 55 02 AM" src="https://github.com/user-attachments/assets/34fde82f-bc0b-4a4f-9f29-e9543a0c72db">


