### PR TITLE
Add claude-3-haiku to the documentation

### DIFF
--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -614,7 +614,7 @@ class TLMOptions(TypedDict):
 
     Args:
         model (str, default = "gpt-3.5-turbo-16k"): underlying LLM to use (better models will yield better results).
-        Models currently supported include "gpt-3.5-turbo-16k", "gpt-4", "gpt-4o".
+        Models currently supported include "gpt-3.5-turbo-16k", "gpt-4", "gpt-4o", "claude-3-haiku".
 
         max_tokens (int, default = 512): the maximum number of tokens to generate in the TLM response.
         This number will impact the maximum number of tokens you will see in the output response, and also the number of tokens


### PR DESCRIPTION
Tested the model latency and token calculation with https://github.com/cleanlab/sandbox/blob/main/TLM-bedrock/bedrock_haiku_test.ipynb.

<img width="1044" alt="Screenshot 2024-07-16 at 5 37 56 PM" src="https://github.com/user-attachments/assets/57eac1e1-8299-4520-b51a-f26dc0bd25c2">
<img width="1051" alt="Screenshot 2024-07-16 at 5 38 38 PM" src="https://github.com/user-attachments/assets/968c6ecb-ffad-42fa-a349-6cb04e49c50d">
