### PR TITLE
Update typing for TLM log

### DIFF
--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -631,7 +631,7 @@ class TLMResponse(TypedDict):
 
     response: str
     trustworthiness_score: Optional[float]
-    log: Optional[Dict[str, Any]]
+    log: NotRequired[Dict[str, Any]]
 
 
 class TLMScore(TypedDict):
@@ -641,7 +641,7 @@ class TLMScore(TypedDict):
     """
 
     trustworthiness_score: Optional[float]
-    log: Optional[Dict[str, Any]]
+    log: NotRequired[Dict[str, Any]]
 
 
 TLMScoreResponse = Union[float, TLMScore]


### PR DESCRIPTION
Small typing update - `log` was previously wrongly specified to be `Optional` (ie. it has to be present in the dict but can have a value of `None`), but it should instead be `NotRequired` (ie. does not have to be in the dict)