### PR TITLE
docs fix: remove api_key arg from docstring of TLM

### DIFF
--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -47,8 +47,6 @@ class TLM:
     After you've instantiated the TLM object using [`Studio.TLM()`](../studio/#method-tlm), you can use the instance methods documented on this page. Possible arguments for `Studio.TLM()` are documented below.
 
     Args:
-        api_key: You can find your API key on your [account page](https://app.cleanlab.ai/account) in Cleanlab Studio. Instead of specifying the API key here, you can also log in with `cleanlab login` on the command-line.
-
         quality_preset (TLMQualityPreset, default = "medium"): An optional preset configuration to control the quality of TLM responses and trustworthiness scores vs. runtimes/costs. TLMQualityPreset is a string specifying one of the supported presets: "best", "high", "medium", "low", "base".
 
             The "best" and "high" presets return improved LLM responses,


### PR DESCRIPTION
This is not a valid arg, think it got accidentally copied in the docstring when moving from studio -> trustworthy_language_model module

![Screen Shot 2024-07-17 at 9 05 27 PM](https://github.com/user-attachments/assets/c47df35e-27bc-4c39-95fd-7742ae414ae1)
