### PR TITLE
[bugfix] "ModuleNotFoundError: No module named 'snowflake.snowpark'" that happens when running Studio API tutorials

### DIFF
--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -26,6 +26,7 @@ from io import StringIO
 
 try:
     import snowflake
+    import snowflake.snowpark as snowpark
 
     snowflake_exists = True
 except ImportError:


### PR DESCRIPTION
Once this bugfix is merged in, please ask @aditya1503 why #benchmark-studio regression tests did not catch this.

This is high-priority bug that affects API users.

<img width="824" alt="Screen Shot 2024-07-29 at 7 30 36 PM" src="https://github.com/user-attachments/assets/ac0f74a6-7ada-49c8-8b94-593354f8234b">
