### PR TITLE
Add method to print TLM model name

### DIFF
--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -12,6 +12,7 @@ _VALID_TLM_MODELS: List[str] = [
     "claude-3-sonnet",
     "claude-3.5-sonnet",
 ]
+_TLM_DEFAULT_MODEL: str = "gpt-4o-mini"
 _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 TLM_MAX_TOKEN_RANGE: Tuple[int, int] = (64, 512)  # (min, max)
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: Tuple[int, int] = (1, 20)  # (min, max)

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -98,10 +98,16 @@ class TLM:
             )
 
         self._return_log = False
-        if options is not None:
-            validate_tlm_options(options)
-            if "log" in options.keys():
-                self._return_log = True
+
+        options_dict = options or {}
+        validate_tlm_options(options_dict)
+        if "log" in options_dict.keys():
+            self._return_log = True
+
+        # explicitly specify the default model
+        self._options = {**{"model": _TLM_DEFAULT_MODEL}, **options_dict}
+
+        self._quality_preset = quality_preset
 
         if timeout is not None and not (isinstance(timeout, int) or isinstance(timeout, float)):
             raise ValidationError("timeout must be a integer or float value")
@@ -111,8 +117,6 @@ class TLM:
 
         is_notebook_flag = is_notebook()
 
-        self._quality_preset = quality_preset
-        self._options = options
         self._timeout = timeout if timeout is not None and timeout > 0 else None
         self._verbose = verbose if verbose is not None else is_notebook_flag
 
@@ -619,10 +623,7 @@ class TLM:
 
     def print_model_name(self) -> None:
         """Prints the underlying LLM used to obtain responses and scoring trustworthiness."""
-        model_name = (
-            self._options.get("model", _TLM_DEFAULT_MODEL) if self._options else _TLM_DEFAULT_MODEL
-        )
-        print(model_name)
+        print(self._options["model"])
 
 
 class TLMResponse(TypedDict):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -622,7 +622,7 @@ class TLM:
             raise e
 
     def get_model_name(self) -> str:
-        """Returns the underlying LLM used to obtain responses and scoring trustworthiness."""
+        """Returns the underlying LLM used to generate responses and score their trustworthiness."""
         return cast(str, self._options["model"])
 
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -621,9 +621,9 @@ class TLM:
                 return None
             raise e
 
-    def print_model_name(self) -> None:
-        """Prints the underlying LLM used to obtain responses and scoring trustworthiness."""
-        print(self._options["model"])
+    def get_model_name(self) -> str:
+        """Returns the underlying LLM used to obtain responses and scoring trustworthiness."""
+        return cast(str, self._options["model"])
 
 
 class TLMResponse(TypedDict):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -24,6 +24,7 @@ from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.constants import (
     _TLM_MAX_RETRIES,
     _VALID_TLM_QUALITY_PRESETS,
+    _TLM_DEFAULT_MODEL,
 )
 from cleanlab_studio.internal.tlm.concurrency import TlmRateHandler
 from cleanlab_studio.internal.tlm.validation import (
@@ -615,6 +616,13 @@ class TLM:
             if capture_exceptions:
                 return None
             raise e
+
+    def print_model_name(self) -> None:
+        """Prints the underlying LLM used to obtain responses and scoring trustworthiness."""
+        model_name = (
+            self._options.get("model", _TLM_DEFAULT_MODEL) if self._options else _TLM_DEFAULT_MODEL
+        )
+        print(model_name)
 
 
 class TLMResponse(TypedDict):

--- a/cleanlab_studio/utils/tlm_hybrid.py
+++ b/cleanlab_studio/utils/tlm_hybrid.py
@@ -4,7 +4,7 @@ TLMHybrid is a hybrid version of the [Trustworthy Language Model (TLM)](../trust
 **This module is not meant to be imported and used directly.** Instead, use [`Studio.TLMHybrid()`](/reference/python/studio/#method-tlmhybrid) to instantiate a [TLMHybrid](#class-tlmhybrid) object, and then you can use the methods like [`prompt()`](#method-prompt) documented on this page.
 """
 
-from typing import List, Optional, Union, cast, Sequence
+from typing import List, Dict, Optional, Union, cast, Sequence
 import numpy as np
 
 from cleanlab_studio.errors import ValidationError
@@ -254,9 +254,9 @@ class TLMHybrid:
         else:
             raise ValueError(f"score_response has invalid type")
 
-    def print_model_name(self) -> None:
-        """Prints the underlying LLMs used to obtain responses and scoring trustworthiness."""
-        print("Response model:", end=" ")
-        self._tlm_response.print_model_name()
-        print("Score model:", end=" ")
-        self._tlm_score.print_model_name()
+    def get_model_names(self) -> Dict[str, str]:
+        """Returns the underlying LLMs used to obtain responses and scoring trustworthiness."""
+        return {
+            "response_model": self._tlm_response.get_model_name(),
+            "score_model": self._tlm_score.get_model_name(),
+        }

--- a/cleanlab_studio/utils/tlm_hybrid.py
+++ b/cleanlab_studio/utils/tlm_hybrid.py
@@ -255,7 +255,7 @@ class TLMHybrid:
             raise ValueError(f"score_response has invalid type")
 
     def get_model_names(self) -> Dict[str, str]:
-        """Returns the underlying LLMs used to obtain responses and scoring trustworthiness."""
+        """Returns the underlying LLMs used to generate responses and score their trustworthiness."""
         return {
             "response_model": self._tlm_response.get_model_name(),
             "score_model": self._tlm_score.get_model_name(),

--- a/cleanlab_studio/utils/tlm_hybrid.py
+++ b/cleanlab_studio/utils/tlm_hybrid.py
@@ -253,3 +253,10 @@ class TLMHybrid:
             ]
         else:
             raise ValueError(f"score_response has invalid type")
+
+    def print_model_name(self) -> None:
+        """Prints the underlying LLMs used to obtain responses and scoring trustworthiness."""
+        print("Response model:", end=" ")
+        self._tlm_response.print_model_name()
+        print("Score model:", end=" ")
+        self._tlm_score.print_model_name()

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.1.9"
+__version__ = "2.1.10"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
Adds new method `get_model_name()` to easily know which model the TLM is using.

I've also explicitly specified which default model is being used in the client API call to the backend. Currently, if no model is specified from the client, we use the default in the backend but this `get_model_name()` method can get outdated if someone uses an older version of the client library against an updated backend.

Sample usage:

```python
tlm = studio.TLM()
tlm.get_model_name()

>> 'gpt-4o-mini'
```

```python
tlm = studio.TLM(options={"model": "claude-3-haiku"})
tlm.get_model_name()

>> 'claude-3-haiku'
```

```python
tlm_hybrid = studio.TLMHybrid()
tlm_hybrid.get_model_names()

>> {'response_model': 'gpt-4o', 'score_model': 'gpt-4o-mini'}
```