### PR TITLE
[DE] implement `wait_until_ready` function for `EnrichmentProject`

### DIFF
--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -156,3 +156,7 @@ class InvalidFilepathError(HandledError):
 
 class InvalidCsvFilename(HandledError):
     pass
+
+
+class EnrichmentProjectError(InternalError):
+    pass

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -192,7 +192,7 @@ class EnrichmentProject:
         )
         return response
 
-    def _get_latest_job(self) -> dict:
+    def _get_latest_job(self) -> EnrichmentJob:
         """Retrieve the latest job and its details."""
         return self.list_all_jobs()[0]
 

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -33,7 +33,6 @@ REGEX_PARAMETER_ERROR_MESSAGE = (
     "The 'regex' parameter must be a string, a tuple(str, str), or a list of tuple(str, str)."
 )
 CLEANLAB_ROW_ID_COLUMN_NAME = "cleanlab_row_ID"
-CHECK_READY_INTERVAL = 60 * 2  # 2 minutes
 
 
 class EnrichmentJobStatusEnum(Enum):

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -33,6 +33,7 @@ REGEX_PARAMETER_ERROR_MESSAGE = (
     "The 'regex' parameter must be a string, a tuple(str, str), or a list of tuple(str, str)."
 )
 CLEANLAB_ROW_ID_COLUMN_NAME = "cleanlab_row_ID"
+CHECK_READY_INTERVAL = 100
 
 
 class EnrichmentJobStatusEnum(Enum):
@@ -257,7 +258,7 @@ class EnrichmentProject:
                 pbar.set_postfix_str(latest_job_status["status"])
                 pbar.update(num_processed_rows - pbar.n)
 
-                for _ in range(50):
+                for _ in range(CHECK_READY_INTERVAL):
                     time.sleep(0.1)
                     pbar.set_description_str(f"Enrichment Progress: {next(spinner)}")
 

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -214,6 +214,8 @@ class EnrichmentProject:
         """Check if the latest populate job is ready."""
         latest_job = self._get_latest_job()
         if latest_job["job_type"] != "ENRICHMENT":
+            # TODO: consider fetching latest populate job directly instead of throwing an error
+            # This would prevent the user from getting stuck in an error state if preview job is the latest job
             raise ValueError(
                 "The latest job is a preview, to execute against entire dataset, please do `run()` first."
             )
@@ -243,7 +245,6 @@ class EnrichmentProject:
             while not self.ready:
                 latest_job_status = self._get_latest_job_status()
                 self._update_progress_bar(pbar, latest_job_status)
-
                 for _ in range(CHECK_READY_INTERVAL):
                     time.sleep(0.1)
                     pbar.set_description_str(f"Enrichment Progress: {next(spinner)}")
@@ -252,7 +253,6 @@ class EnrichmentProject:
                     raise EnrichmentProjectError(
                         f"Project {self.id} failed to complete. Error: {latest_job_status['error']}"
                     )
-
             latest_job_status = self._get_latest_job_status()
             self._update_progress_bar(pbar, latest_job_status)
 

--- a/cleanlab_studio/studio/enrichment.py
+++ b/cleanlab_studio/studio/enrichment.py
@@ -202,7 +202,7 @@ class EnrichmentProject:
         return api.get_enrichment_job_status(self._api_key, job_id=latest_job["id"])
 
     def _get_num_processed_rows(self) -> int:
-        num_rows = self._get_enrichment_project_dict()["num_rows"]
+        num_rows = int(self._get_enrichment_project_dict()["num_rows"])
         latest_job_status = self._get_latest_job_status()
         status = latest_job_status["status"]
         if status == EnrichmentJobStatusEnum.SUCCEEDED.value:


### PR DESCRIPTION
The `wait_until_ready` function is designed to wait until the latest enrichment job is completed. It uses a progress bar to provide visual feedback on the job's progress.
- `num_rows` is the total # rows for the dataset and comes from the enrichment project dict. `processed_rows` is the value of currently processed rows and comes from the enrichment job status endpoint. these are used in the progress. the loop continues until `self.ready` is `True`
- `_get_num_processed_rows` helper function, because the status endpoint only returns the `processed_rows` property if the status is running. note: we may want to include this logic in the backend instead of python client
- refactored `self._latest_populate_job` to use `_get_latest_job` helper function. the previous implementation was problematic because it fetched the latest job of all types, including preview jobs, which made the naming misleading. maintaining an instance variable required constant updates across various helper functions, making the code harder to manage than fetching the latest job directly from the backend 


https://github.com/user-attachments/assets/40cd90f8-0fa5-48f6-a097-b86524fc552c


