### PR TITLE
[TLM] Add custom types to docstrings

### DIFF
--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -10,8 +10,8 @@ The [Trustworthy Language Model tutorial](/tutorials/tlm/) further explains TLM 
 Type aliases returned by the TLM module.
 
 - `TLMScoreResponse = Union[float, TLMScore]`: a single TLM response that can be either float, representing the trustworthiness score or a [TLMScore](#class-tlmscore) object containing both the trustworthiness score and log dictionary keys.
-- `TLMBatchScoreResponse = Union[List[float], List[TLMScore]]`: a TLM response that can be either a list of floats or a list of [TLMScore](#class-tlmscore) objects containing both the trustworthiness score and log dictionary keys. The list will have the be length as the input list of prompts, response pairs.
-- `TLMOptionalBatchScoreResponse = Union[List[Optional[float]], List[Optional[TLMScore]]]`:  a TLM response that can be either a list of floats or None (if the call to the TLM failed) or a list of [TLMScore](#class-tlmscore) objects containing both the trustworthiness score and log dictionary keys or None (if the call to the TLM failed). The list will have the be length as the input list of prompts, response pairs.
+- `TLMBatchScoreResponse = Union[List[float], List[TLMScore]]`: a TLM response that can be either a list of floats or a list of [TLMScore](#class-tlmscore) objects containing both the trustworthiness score and log dictionary keys. The list will have the same length as the input list of prompts, response pairs.
+- `TLMOptionalBatchScoreResponse = Union[List[Optional[float]], List[Optional[TLMScore]]]`:  a TLM response that can be either a list of floats or None (if the call to the TLM failed) or a list of [TLMScore](#class-tlmscore) objects containing both the trustworthiness score and log dictionary keys or None (if the call to the TLM failed). The list will have the same length as the input list of prompts, response pairs.
 """
 
 from __future__ import annotations

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -22,9 +22,9 @@ from typing_extensions import (  # for Python <3.11 with (Not)Required
 from cleanlab_studio.errors import ValidationError
 from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.constants import (
+    _TLM_DEFAULT_MODEL,
     _TLM_MAX_RETRIES,
     _VALID_TLM_QUALITY_PRESETS,
-    _TLM_DEFAULT_MODEL,
 )
 from cleanlab_studio.internal.tlm.concurrency import TlmRateHandler
 from cleanlab_studio.internal.tlm.validation import (
@@ -655,8 +655,19 @@ class TLMScore(TypedDict):
 
 
 TLMScoreResponse = Union[float, TLMScore]
+"""
+TLMScoreResponse represents a single TLM response that can be either float, representing the trustworthiness score or a TLMScore object containing both the trustworthiness score and log dictionary keys.
+"""
+
 TLMBatchScoreResponse = Union[List[float], List[TLMScore]]
+"""
+TLMBatchScoreResponse represents a TLM response that can be either a list of floats or a list of TLMScore objects. The list will have the be length as the input list of prompts, response pairs.
+"""
+
 TLMOptionalBatchScoreResponse = Union[List[Optional[float]], List[Optional[TLMScore]]]
+"""
+TLMOptionalBatchScoreResponse represents a TLM response that can be either a list of floats or None (if the call to the TLM failed) or a list of TLMScore objects or None (if the call to the TLM failed). The list will have the be length as the input list of prompts, response pairs.
+"""
 
 
 class TLMOptions(TypedDict):

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -192,7 +192,7 @@ class TLM:
             capture_exceptions (bool): if should return None in place of the response for any errors or timeout processing some inputs
 
         Returns:
-            Union[TLMBatchScoreResponse, TLMOptionalBatchScoreResponse]: TLM trustworthiness score for each prompt (in supplied order)
+            Union[TLMBatchScoreResponse, TLMOptionalBatchScoreResponse]: TLM trustworthiness score for each prompt (in supplied order).
         """
         if capture_exceptions:
             per_query_timeout, per_batch_timeout = self._timeout, None
@@ -437,8 +437,10 @@ class TLM:
             response (str | Sequence[str]): existing response (or list of responses) associated with the input prompts.
                 These can be from any LLM or human-written responses.
         Returns:
-            float | List[float]: float or list of floats (if multiple prompt-responses were provided) corresponding
-                to the TLM's trustworthiness score.
+            TLMScoreResponse | TLMBatchScoreResponse: **TLMScoreResponse** represents a single TLM response that can be either float, representing the trustworthiness score or a TLMScore object containing both the trustworthiness score and log dictionary keys.
+
+                **TLMBatchScoreResponse** (if multiple prompt-responses were provided) represents a TLM response that can be either a list of floats or a list of TLMScore objects. The list will have the be length as the input list of prompts, response pairs.
+
                 The score quantifies how confident TLM is that the given response is good for the given prompt.
                 If running on many prompt-response pairs simultaneously:
                 this method will raise an exception if any TLM errors or timeouts occur.
@@ -493,7 +495,7 @@ class TLM:
             prompt (Sequence[str]): list of prompts for the TLM to evaluate
             response (Sequence[str]): list of existing responses corresponding to the input prompts (from any LLM or human-written)
         Returns:
-            List[float]: list of floats corresponding to the TLM's trustworthiness score.
+            TLMOptionalBatchScoreResponse: a TLM response that can be either a list of floats or None (if the call to the TLM failed) or a list of TLMScore objects or None (if the call to the TLM failed). The list will have the be length as the input list of prompts, response pairs. The floats correspond to the TLM's trustworthiness score.
                 The score quantifies how confident TLM is that the given response is good for the given prompt.
                 The returned list will always have the same length as the input list.
                 In case of TLM error or timeout on any prompt-response pair,
@@ -537,8 +539,9 @@ class TLM:
             prompt (str | Sequence[str]): prompt (or list of prompts) for the TLM to evaluate
             response (str | Sequence[str]): response (or list of responses) corresponding to the input prompts
         Returns:
-            float | List[float]: float or list of floats (if multiple prompt-responses were provided) corresponding
-                to the TLM's trustworthiness score.
+            TLMScoreResponse | float | List[float]: **TLMScoreResponse** represents a single TLM response that can be either float, representing the trustworthiness score or a TLMScore object
+                containing both the trustworthiness score and log dictionary keys,
+                or float or list of floats (if multiple prompt-responses were provided) corresponding to the TLM's trustworthiness score.
                 The score quantifies how confident TLM is that the given response is good for the given prompt.
                 This method will raise an exception if any errors occur or if you hit a timeout (given a timeout is specified).
         """
@@ -655,19 +658,8 @@ class TLMScore(TypedDict):
 
 
 TLMScoreResponse = Union[float, TLMScore]
-"""
-TLMScoreResponse represents a single TLM response that can be either float, representing the trustworthiness score or a TLMScore object containing both the trustworthiness score and log dictionary keys.
-"""
-
 TLMBatchScoreResponse = Union[List[float], List[TLMScore]]
-"""
-TLMBatchScoreResponse represents a TLM response that can be either a list of floats or a list of TLMScore objects. The list will have the be length as the input list of prompts, response pairs.
-"""
-
 TLMOptionalBatchScoreResponse = Union[List[Optional[float]], List[Optional[TLMScore]]]
-"""
-TLMOptionalBatchScoreResponse represents a TLM response that can be either a list of floats or None (if the call to the TLM failed) or a list of TLMScore objects or None (if the call to the TLM failed). The list will have the be length as the input list of prompts, response pairs.
-"""
 
 
 class TLMOptions(TypedDict):

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
This change will allow our custom defined types to show up on help.cleanlab.ai [here](https://help.cleanlab.ai/reference/python/trustworthy_language_model/)