### PR TITLE
[TLM] Fix get_trustworthiness_score_async type check

### DIFF
--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -546,7 +546,7 @@ class TLM:
         processed_response = process_response_and_kwargs(response, kwargs)
 
         async with aiohttp.ClientSession() as session:
-            if isinstance(prompt, str) and isinstance(processed_response, str):
+            if isinstance(prompt, str) and isinstance(processed_response, dict):
                 trustworthiness_score = await self._get_trustworthiness_score_async(
                     prompt,
                     processed_response,

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
This code snippet was erroring out due to a bad type check:

```python
tlm = studio.TLM() 
trustworthiness_score = await tlm.get_trustworthiness_score_async("what is 1+1", response="2")
```

This PR should fix that.