### PR TITLE
[TLM] log error msg from try_prompt and try_get_trustworthiness_score

### DIFF
--- a/cleanlab_studio/errors.py
+++ b/cleanlab_studio/errors.py
@@ -79,7 +79,9 @@ class RateLimitError(HandledError):
 
 
 class TlmBadRequest(HandledError):
-    pass
+    def __init__(self, message: str, retryable: bool):
+        self.message = message
+        self.retryable = retryable
 
 
 class TlmServerError(APIError):

--- a/cleanlab_studio/internal/api/api.py
+++ b/cleanlab_studio/internal/api/api.py
@@ -115,13 +115,14 @@ async def handle_tlm_client_error_from_resp(
         try:
             res_json = await resp.json()
             error_message = res_json["error"]
+            retryable = False
         except Exception:
             error_message = "TLM query failed. Please try again and contact support@cleanlab.ai if the problem persists."
-
+            retryable = True
         if batch_index is not None:
             error_message = f"Error executing query at index {batch_index}:\n{error_message}"
 
-        raise TlmBadRequest(error_message)
+        raise TlmBadRequest(error_message, retryable)
 
 
 async def handle_tlm_api_error_from_resp(

--- a/cleanlab_studio/internal/enrichment_utils.py
+++ b/cleanlab_studio/internal/enrichment_utils.py
@@ -14,7 +14,7 @@ Replacement = Tuple[str, str]
 
 def get_prompt_outputs(
     studio: Studio, prompt: str, data: pd.DataFrame, **kwargs: Any
-) -> List[Optional[TLMResponse]]:
+) -> List[TLMResponse]:
     """Returns the outputs of the prompt for each row in the dataframe."""
     default_tlm_options = {"model": "claude-3-haiku"}
     tlm_options = kwargs.get("options", {})

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -416,7 +416,7 @@ class TLM:
             List[TLMResponse]: list of [TLMResponse](#class-tlmresponse) objects containing the response and trustworthiness score.
                 The returned list will always have the same length as the input list.
                 In case of TLM failure on any prompt (due to timeouts or other errors),
-                the return list will include a [TLMResponse](#class-tlmresponse) with an error message and retryability information instead of the usual TLM response for that failed prompt.
+                the return list will include a [TLMResponse](#class-tlmresponse) with an error message and retryability information instead of the usual TLMResponse for that failed prompt.
                 Use this method to obtain TLM results for as many prompts as possible, while handling errors/timeouts manually.
                 If you prefer immediate notification about any errors or timeouts when processing multiple prompts,
                 use the [`prompt()`](#method-prompt) method instead.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -462,6 +462,18 @@ class TLM:
         capture_exceptions: bool = False,
         batch_index: Optional[int] = None,
     ) -> TLMResponse:
+        """
+        Private asynchronous method to get response and trustworthiness score from TLM.
+
+        Args:
+            prompt (str): prompt for the TLM
+            client_session (aiohttp.ClientSession, optional): async HTTP session to use for TLM query. Defaults to None (creates a new session).
+            timeout: timeout (in seconds) to run the prompt, defaults to None (no timeout)
+            capture_exceptions (bool): if True, the returned [TLMResponse](#class-tlmresponse) object will include error details and retry information if any errors or timeouts occur during processing.
+            batch_index: index of the prompt in the batch, used for error messages
+        Returns:
+            TLMResponse: [TLMResponse](#class-tlmresponse) object containing the response and trustworthiness score.
+        """
         response_json = await asyncio.wait_for(
             api.tlm_prompt(
                 self._api_key,
@@ -632,6 +644,18 @@ class TLM:
         capture_exceptions: bool = False,
         batch_index: Optional[int] = None,
     ) -> TLMScore:
+        """Private asynchronous method to get trustworthiness score for prompt-response pairs.
+
+        Args:
+            prompt: prompt for the TLM to evaluate
+            response: response corresponding to the input prompt
+            client_session: async HTTP session to use for TLM query. Defaults to None.
+            timeout: timeout (in seconds) to run the prompt, defaults to None (no timeout)
+            capture_exceptions (bool): if True, the returned [TLMScore](#class-tlmscore) object will include error details and retry information if any errors or timeouts occur during processing.
+            batch_index: index of the prompt in the batch, used for error messages
+        Returns:
+            [TLMScore](#class-tlmscore) objects with error messages and retryability information in place of the trustworthiness score
+        """
         response_json = await asyncio.wait_for(
             api.tlm_get_confidence_score(
                 self._api_key,

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -754,7 +754,7 @@ class TLMResponse(TypedDict):
         log (dict, optional): additional logs and metadata returned from the LLM call only if the `log` key was specified in TLMOptions.
     """
 
-    response: str
+    response: Optional[str]
     trustworthiness_score: Optional[float]
     log: NotRequired[Dict[str, Any]]
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -12,18 +12,7 @@ import asyncio
 import sys
 import warnings
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Sequence, Union, cast
 
 import aiohttp
 from tqdm.asyncio import tqdm_asyncio
@@ -63,6 +52,11 @@ def handle_tlm_exceptions(
     [Callable[..., Coroutine[Any, Any, Union[TLMResponse, TLMScore]]]],
     Callable[..., Coroutine[Any, Any, Union[TLMResponse, TLMScore]]],
 ]:
+    """Decorator to handle exceptions for TLM API calls.
+
+    lazydocs: ignore
+    """
+
     def decorator(
         func: Callable[..., Coroutine[Any, Any, Union[TLMResponse, TLMScore]]]
     ) -> Callable[..., Coroutine[Any, Any, Union[TLMResponse, TLMScore]]]:

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -486,7 +486,7 @@ class TLM:
             response (str | Sequence[str]): existing response (or list of responses) associated with the input prompts.
                 These can be from any LLM or human-written responses.
         Returns:
-            TLMScore | List[TLMScore]: If a single prompt/response pair was passed in, method returns a TLMScore object containing the trustworthiness score and optional log dictionary keys.
+            TLMScore | List[TLMScore]: If a single prompt/response pair was passed in, method returns a [TLMScore](#class-tlmscore) object containing the trustworthiness score and optional log dictionary keys.
 
                 If a list of prompt/responses was passed in, method returns a list of TLMScore objects each containing the trustworthiness score and optional log dictionary keys for each prompt-response pair passed in.
 

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -22,9 +22,9 @@ from typing_extensions import (  # for Python <3.11 with (Not)Required
 )
 
 from cleanlab_studio.errors import (
+    APITimeoutError,
     RateLimitError,
     TlmBadRequest,
-    TlmPartialSuccess,
     TlmServerError,
     ValidationError,
 )
@@ -66,6 +66,16 @@ def handle_tlm_exceptions(
             batch_index = kwargs.get("batch_index")
             try:
                 return await func(*args, **kwargs)
+            except asyncio.TimeoutError as e:
+                return _handle_exception(
+                    APITimeoutError(
+                        f"Timeout while waiting for prediction. Please retry or consider increasing the timeout."
+                    ),
+                    capture_exceptions,
+                    batch_index,
+                    retryable=True,
+                    response_type=response_type,
+                )
             except RateLimitError as e:
                 return _handle_exception(
                     e, capture_exceptions, batch_index, retryable=True, response_type=response_type

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -405,7 +405,7 @@ class TLM:
         Gets response and trustworthiness score for any batch of prompts handling any failures (errors or timeouts).
 
         The list returned will have the same length as the input list. If there are any
-        failures (errors or timeouts) processing some inputs, the list will contain [TLMResponse](#class-tlmresponse) objects with error messages and retryability information instead of the usual response.
+        failures (errors or timeouts) processing some inputs, the [TLMResponse](#class-tlmresponse) objects in the returned list will contain error messages and retryability information instead of the usual response.
 
         This is the recommended approach for obtaining TLM responses and trustworthiness scores for large datasets with many prompts,
         where some individual TLM responses within the dataset might fail. It ensures partial results are preserved.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -304,11 +304,8 @@ class TLM:
                 ),
             )
 
-        return cast(
-            List[TLMResponse],
-            self._event_loop.run_until_complete(
-                self._batch_prompt(prompt, capture_exceptions=False),
-            ),
+        return self._event_loop.run_until_complete(
+            self._batch_prompt(prompt, capture_exceptions=False),
         )
 
     def try_prompt(
@@ -339,11 +336,8 @@ class TLM:
         """
         validate_tlm_try_prompt(prompt)
 
-        return cast(
-            List[TLMResponse],
-            self._event_loop.run_until_complete(
-                self._batch_prompt(prompt, capture_exceptions=True),
-            ),
+        return self._event_loop.run_until_complete(
+            self._batch_prompt(prompt, capture_exceptions=True),
         )
 
     async def prompt_async(
@@ -376,10 +370,7 @@ class TLM:
                 )
                 return cast(TLMResponse, tlm_response)
 
-            return cast(
-                List[TLMResponse],
-                await self._batch_prompt(prompt, capture_exceptions=False),
-            )
+            return await self._batch_prompt(prompt, capture_exceptions=False)
 
     async def _prompt_async(
         self,
@@ -525,13 +516,10 @@ class TLM:
 
         assert isinstance(prompt, Sequence) and isinstance(processed_response, Sequence)
 
-        return cast(
-            List[TLMScore],
-            self._event_loop.run_until_complete(
-                self._batch_get_trustworthiness_score(
-                    prompt, processed_response, capture_exceptions=False
-                )
-            ),
+        return self._event_loop.run_until_complete(
+            self._batch_get_trustworthiness_score(
+                prompt, processed_response, capture_exceptions=False
+            )
         )
 
     def try_get_trustworthiness_score(
@@ -569,15 +557,12 @@ class TLM:
 
         assert isinstance(processed_response, list)
 
-        return cast(
-            List[TLMScore],
-            self._event_loop.run_until_complete(
-                self._batch_get_trustworthiness_score(
-                    prompt,
-                    processed_response,
-                    capture_exceptions=True,
-                )
-            ),
+        return self._event_loop.run_until_complete(
+            self._batch_get_trustworthiness_score(
+                prompt,
+                processed_response,
+                capture_exceptions=True,
+            )
         )
 
     async def get_trustworthiness_score_async(
@@ -620,11 +605,8 @@ class TLM:
 
             assert isinstance(prompt, Sequence) and isinstance(processed_response, Sequence)
 
-            return cast(
-                List[TLMScore],
-                await self._batch_get_trustworthiness_score(
-                    prompt, processed_response, capture_exceptions=False
-                ),
+            return await self._batch_get_trustworthiness_score(
+                prompt, processed_response, capture_exceptions=False
             )
 
     async def _get_trustworthiness_score_async(

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -285,7 +285,7 @@ class TLM:
         Args:
             prompts (Sequence[str]): list of prompts to run get trustworthiness score for
             responses (Sequence[str]): list of responses to run get trustworthiness score for
-            capture_exceptions (bool): if should return None in place of the response for any errors or timeout processing some inputs
+            capture_exceptions (bool): if True, the returned list will contain [TLMScore](#class-tlmscore) objects with error messages and retryability information in place of the score for any errors or timeout when processing a particular prompt from the batch.
 
         Returns:
             List[TLMScore]: TLM trustworthiness score for each prompt (in supplied order).
@@ -402,8 +402,7 @@ class TLM:
         /,
     ) -> List[TLMResponse]:
         """
-        Gets response and trustworthiness score for any batch of prompts,
-        handling any failures (errors or timeouts) by returning error messages and retryability information in place of the failures.
+        Gets response and trustworthiness score for any batch of prompts handling any failures (errors or timeouts).
 
         The list returned will have the same length as the input list. If there are any
         failures (errors or timeouts) processing some inputs, the list will contain [TLMResponse](#class-tlmresponse) objects with error messages and retryability information instead of the usual response.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import warnings
 from typing import Any, Coroutine, Dict, List, Optional, Sequence, Union, cast
 
 import aiohttp
@@ -27,7 +28,13 @@ from typing_extensions import (  # for Python <3.11 with (Not)Required
     TypedDict,
 )
 
-from cleanlab_studio.errors import RateLimitError, ValidationError, TlmBadRequest, TlmServerError, TlmPartialSuccess
+from cleanlab_studio.errors import (
+    RateLimitError,
+    TlmBadRequest,
+    TlmPartialSuccess,
+    TlmServerError,
+    ValidationError,
+)
 from cleanlab_studio.internal.api import api
 from cleanlab_studio.internal.constants import (
     _TLM_DEFAULT_MODEL,
@@ -44,8 +51,6 @@ from cleanlab_studio.internal.tlm.validation import (
     validate_try_tlm_prompt_response,
 )
 from cleanlab_studio.internal.types import TLMQualityPreset
-
-import warnings
 
 
 class TLM:
@@ -421,67 +426,57 @@ class TLM:
             )
         except RateLimitError as e:
             if capture_exceptions:
-                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                warning_message = (
+                    f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                )
                 warnings.warn(warning_message)
 
                 return TLMResponse(
                     response=None,
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e.message),
-                            "retryable": True
-                        }
-                    }
+                    log={"error": {"message": str(e.message), "retryable": True}},
                 )
             raise e
         except TlmBadRequest as e:
             if capture_exceptions:
-                retry_message = "Worth retrying." if e.retryable else "Retrying will not help. Please address the issue described in the error message before attempting again."
-                warning_message = f"prompt[{batch_index}] failed. {retry_message} Error: {str(e.message)}"
+                retry_message = (
+                    "Worth retrying."
+                    if e.retryable
+                    else "Retrying will not help. Please address the issue described in the error message before attempting again."
+                )
+                warning_message = (
+                    f"prompt[{batch_index}] failed. {retry_message} Error: {str(e.message)}"
+                )
                 warnings.warn(warning_message)
-                
+
                 return TLMResponse(
                     response=None,
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e.message),
-                            "retryable": e.retryable
-                        }
-                    }
+                    log={"error": {"message": str(e.message), "retryable": e.retryable}},
                 )
             raise e
         except TlmServerError as e:
             if capture_exceptions:
-                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                warning_message = (
+                    f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                )
                 warnings.warn(warning_message)
 
                 return TLMResponse(
                     response=None,
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e.message),
-                            "retryable": True
-                        }
-                    }
+                    log={"error": {"message": str(e.message), "retryable": True}},
                 )
             raise e
         except Exception as e:
             if capture_exceptions:
-                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e)}"
                 warnings.warn(warning_message)
 
                 return TLMResponse(
                     response=None,
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e),
-                            "retryable": True
-                        }
-                    }
+                    log={"error": {"message": str(e), "retryable": True}},
                 )
             raise e
 
@@ -685,69 +680,60 @@ class TLM:
                     "log": response_json["log"],
                 }
 
-            return {
-                "trustworthiness_score": response_json["confidence_score"]
-            }
+            if capture_exceptions:
+                return {"trustworthiness_score": response_json["confidence_score"]}
+            else:
+                return cast(float, response_json["confidence_score"])
 
         except RateLimitError as e:
             if capture_exceptions:
-                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                warning_message = (
+                    f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                )
                 warnings.warn(warning_message)
-                
+
                 return TLMScore(
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e.message),
-                            "retryable": True
-                        }
-                    }
+                    log={"error": {"message": str(e.message), "retryable": True}},
                 )
             raise e
         except TlmBadRequest as e:
             if capture_exceptions:
-                retry_message = "Worth retrying." if e.retryable else "Retrying will not help. Please address the issue described in the error message before attempting again."
-                warning_message = f"prompt[{batch_index}] failed. {retry_message} Error: {str(e.message)}"
+                retry_message = (
+                    "Worth retrying."
+                    if e.retryable
+                    else "Retrying will not help. Please address the issue described in the error message before attempting again."
+                )
+                warning_message = (
+                    f"prompt[{batch_index}] failed. {retry_message} Error: {str(e.message)}"
+                )
                 warnings.warn(warning_message)
-                
+
                 return TLMScore(
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e.message),
-                            "retryable": e.retryable
-                        }
-                    }
+                    log={"error": {"message": str(e.message), "retryable": e.retryable}},
                 )
             raise e
         except TlmServerError as e:
             if capture_exceptions:
-                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                warning_message = (
+                    f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                )
                 warnings.warn(warning_message)
 
                 return TLMScore(
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e.message),
-                            "retryable": True
-                        }
-                    }
+                    log={"error": {"message": str(e.message), "retryable": True}},
                 )
             raise e
         except Exception as e:
             if capture_exceptions:
-                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e.message)}"
+                warning_message = f"prompt[{batch_index}] failed. Worth retrying. Error: {str(e)}"
                 warnings.warn(warning_message)
 
                 return TLMScore(
                     trustworthiness_score=None,
-                    log={
-                        "error": {
-                            "message": str(e),
-                            "retryable": True
-                        }
-                    }
+                    log={"error": {"message": str(e), "retryable": True}},
                 )
             raise e
 

--- a/cleanlab_studio/utils/tlm_lite.py
+++ b/cleanlab_studio/utils/tlm_lite.py
@@ -116,26 +116,23 @@ class TLMLite:
         """
         prompt_response = self._tlm_response.prompt(prompt)
 
-        if isinstance(prompt, Sequence) and isinstance(prompt_response, list):
-            response = []
-            perplexity = []
-            for r in prompt_response:
-                if (
-                    r["response"] is None
-                ):  # This condition should theoretically never be true, as the .prompt() method is designed to always return a response unless an exception is raised
-                    raise ValueError("Response cannot be None")
-                response.append(r["response"])
-                perplexity.append(r["log"]["perplexity"])
+        if (
+            isinstance(prompt, Sequence)
+            and isinstance(prompt_response, list)
+            and all(r["response"] is not None for r in prompt_response)
+        ):
+            response = cast(List[str], [r["response"] for r in prompt_response])
+            perplexity = [r["log"]["perplexity"] for r in prompt_response]
             return self._batch_score(prompt, response, perplexity)
 
-        elif isinstance(prompt, str) and isinstance(prompt_response, dict):
-            if (
-                prompt_response["response"] is None
-            ):  # This condition should theoretically never be true, as the .prompt() method is designed to always return a response unless an exception is raised
-                raise ValueError("Response cannot be None")
+        elif (
+            isinstance(prompt, str)
+            and isinstance(prompt_response, dict)
+            and prompt_response["response"] is not None
+        ):
             return self._score(
                 prompt,
-                prompt_response["response"],
+                cast(str, prompt_response["response"]),
                 perplexity=prompt_response["log"]["perplexity"],
             )
 
@@ -145,15 +142,15 @@ class TLMLite:
     def try_prompt(
         self,
         prompt: Sequence[str],
-    ) -> List[Optional[TLMResponse]]:
+    ) -> List[TLMResponse]:
         """
         Similar to [`TLM.try_prompt()`](../trustworthy_language_model/#method-try_prompt), view documentation there for expected input arguments and outputs.
         """
         prompt_response = self._tlm_response.try_prompt(prompt)
-        prompt_succeeded_mask = [res is not None for res in prompt_response]
+        prompt_succeeded_mask = np.array([res["response"] is not None for res in prompt_response])
 
-        if not any(prompt_succeeded_mask):  # all prompts failed
-            return [None] * len(prompt)
+        if not np.any(prompt_succeeded_mask):  # all prompts failed
+            return prompt_response
 
         # handle masking with numpy for easier indexing
         prompt_succeeded = np.array(prompt)[prompt_succeeded_mask].tolist()
@@ -165,10 +162,10 @@ class TLMLite:
             prompt_succeeded, response_succeeded, perplexity_succeeded
         )
 
-        tlm_response = np.full(len(prompt), None)
+        tlm_response = np.array(prompt_response)
         tlm_response[prompt_succeeded_mask] = score_response_succeeded
 
-        return cast(List[Optional[TLMResponse]], tlm_response.tolist())
+        return cast(List[TLMResponse], tlm_response.tolist())
 
     def _score(
         self,
@@ -192,8 +189,6 @@ class TLMLite:
 
         if isinstance(score_response, dict):
             return {"response": response, **score_response}
-        elif isinstance(score_response, (float, int)):
-            return {"response": response, "trustworthiness_score": score_response}
         else:
             raise ValueError(f"score_response has invalid type {type(score_response)}")
 
@@ -223,12 +218,6 @@ class TLMLite:
         if all(isinstance(score, dict) for score in score_response):
             score_response = cast(List[TLMScore], score_response)
             return [{"response": res, **score} for res, score in zip(response, score_response)]
-        elif all(isinstance(score, (float, int)) for score in score_response):
-            score_response = cast(List[float], score_response)
-            return [
-                {"response": res, "trustworthiness_score": score}
-                for res, score in zip(response, score_response)
-            ]
         else:
             raise ValueError(f"score_response has invalid type")
 
@@ -237,7 +226,7 @@ class TLMLite:
         prompt: Sequence[str],
         response: Sequence[str],
         perplexity: Sequence[Optional[float]],
-    ) -> List[Optional[TLMResponse]]:
+    ) -> List[TLMResponse]:
         """
         Private method to get trustworthiness score for a batch of examples and process the outputs into TLMResponse dictionaries,
         handling any failures (errors of timeouts) by returning None in place of the failures.
@@ -256,8 +245,8 @@ class TLMLite:
 
         assert len(prompt) == len(score_response)
 
-        if all(score is None or isinstance(score, dict) for score in score_response):
-            score_response = cast(List[Optional[TLMScore]], score_response)
+        if all(isinstance(score, dict) for score in score_response):
+            score_response = cast(List[TLMScore], score_response)
             return [
                 {"response": res, **score} if score else None
                 for res, score in zip(response, score_response)

--- a/cleanlab_studio/utils/tlm_lite.py
+++ b/cleanlab_studio/utils/tlm_lite.py
@@ -132,7 +132,7 @@ class TLMLite:
         ):
             return self._score(
                 prompt,
-                cast(str, prompt_response["response"]),
+                prompt_response["response"],
                 perplexity=prompt_response["log"]["perplexity"],
             )
 
@@ -246,7 +246,6 @@ class TLMLite:
         assert len(prompt) == len(score_response)
 
         if all(isinstance(score, dict) for score in score_response):
-            score_response = cast(List[TLMScore], score_response)
             return [
                 {"response": res, **score} if score else None
                 for res, score in zip(response, score_response)

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "3.0.0"
+__version__ = "2.5.4"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.5.4"
+__version__ = "2.5.0"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.4.4"
+__version__ = "3.0.0"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"

--- a/tests/tlm/test_get_trustworthiness_score.py
+++ b/tests/tlm/test_get_trustworthiness_score.py
@@ -22,11 +22,7 @@ def is_trustworthiness_score(response: Any) -> bool:
 
 def is_trustworthiness_score_json_format(response: Any) -> bool:
     """Returns True if the response is a trustworthiness score in JSON format."""
-    return (
-        isinstance(response, dict)
-        and "trustworthiness_score" in response
-        and isinstance(response["trustworthiness_score"], float)
-    )
+    return isinstance(response, dict) and "trustworthiness_score" in response
 
 
 def is_valid_tlm_score_response_with_error(response: Any) -> bool:

--- a/tests/tlm/test_get_trustworthiness_score.py
+++ b/tests/tlm/test_get_trustworthiness_score.py
@@ -6,23 +6,14 @@ import pytest
 from cleanlab_studio.studio.trustworthy_language_model import TLM
 
 
-def is_trustworthiness_score(response: Any) -> bool:
-    """Returns True if the response is a trustworthiness score with valid range."""
-    if isinstance(response, float):
-        return 0.0 <= response <= 1.0
-    elif (
+def is_trustworthiness_score_json_format(response: Any) -> bool:
+    """Returns True if the response is a trustworthiness score in JSON format with valid range."""
+    return (
         isinstance(response, dict)
         and "trustworthiness_score" in response
         and isinstance(response["trustworthiness_score"], float)
-    ):
-        return 0.0 <= response["trustworthiness_score"] <= 1.0
-    else:
-        return False
-
-
-def is_trustworthiness_score_json_format(response: Any) -> bool:
-    """Returns True if the response is a trustworthiness score in JSON format."""
-    return isinstance(response, dict) and "trustworthiness_score" in response
+        and 0.0 <= response["trustworthiness_score"] <= 1.0
+    )
 
 
 def is_tlm_score_response_with_error(response: Any) -> bool:
@@ -58,7 +49,7 @@ def test_single_get_trustworthiness_score(tlm: TLM) -> None:
     # - a single response of type TLMResponse is returned
     # - no exceptions are raised (implicit)
     assert response is not None
-    assert is_trustworthiness_score(response)
+    assert is_trustworthiness_score_json_format(response)
 
 
 def test_batch_get_trustworthiness_score(tlm: TLM) -> None:
@@ -82,7 +73,7 @@ def test_batch_get_trustworthiness_score(tlm: TLM) -> None:
     # - no exceptions are raised (implicit)
     assert response is not None
     assert isinstance(response, list)
-    assert all(is_trustworthiness_score(r) for r in response)
+    assert all(is_trustworthiness_score_json_format(r) for r in response)
 
 
 def test_batch_get_trustworthiness_score_force_timeouts(tlm: TLM) -> None:

--- a/tests/tlm/test_get_trustworthiness_score.py
+++ b/tests/tlm/test_get_trustworthiness_score.py
@@ -25,8 +25,8 @@ def is_trustworthiness_score_json_format(response: Any) -> bool:
     return isinstance(response, dict) and "trustworthiness_score" in response
 
 
-def is_valid_tlm_score_response_with_error(response: Any) -> bool:
-    """Validates if the response matches the expected TLMScore with error format."""
+def is_tlm_score_response_with_error(response: Any) -> bool:
+    """Returns True if the response matches the expected TLMScore with error format."""
     return (
         isinstance(response, dict)
         and "trustworthiness_score" in response
@@ -133,7 +133,7 @@ def test_batch_try_get_trustworthiness_score_force_timeouts(tlm: TLM) -> None:
     """Tests running a batch try get_trustworthiness_score in the TLM, forcing timeouts.
 
     Sets timeout to 0.0001 seconds, which should force a timeout for all get_trustworthiness_scores.
-    This should result in None responses for all get_trustworthiness_scores.
+    This should result in TLMResponse with error messages and retryability information for all get_trustworthiness_scores.
 
     Expected:
     - TLM should return a list of responses
@@ -155,4 +155,4 @@ def test_batch_try_get_trustworthiness_score_force_timeouts(tlm: TLM) -> None:
     # - no exceptions are raised (implicit)
     assert response is not None
     assert isinstance(response, list)
-    assert all(is_valid_tlm_score_response_with_error(r) for r in response)
+    assert all(is_tlm_score_response_with_error(r) for r in response)

--- a/tests/tlm/test_get_trustworthiness_score.py
+++ b/tests/tlm/test_get_trustworthiness_score.py
@@ -11,8 +11,13 @@ def is_trustworthiness_score_json_format(response: Any) -> bool:
     return (
         isinstance(response, dict)
         and "trustworthiness_score" in response
-        and isinstance(response["trustworthiness_score"], float)
-        and 0.0 <= response["trustworthiness_score"] <= 1.0
+        and (
+            response["trustworthiness_score"] is None
+            or (
+                isinstance(response["trustworthiness_score"], float)
+                and 0.0 <= response["trustworthiness_score"] <= 1.0
+            )
+        )
     )
 
 

--- a/tests/tlm/test_prompt.py
+++ b/tests/tlm/test_prompt.py
@@ -38,6 +38,21 @@ def is_tlm_response(
     return False
 
 
+def is_tlm_response_with_error(response: Any) -> bool:
+    """Returns True if the response is a TLMResponse with an error."""
+    return (
+        isinstance(response, dict)
+        and "response" in response
+        and response["response"] is None
+        and "trustworthiness_score" in response
+        and response["trustworthiness_score"] is None
+        and "log" in response
+        and "error" in response["log"]
+        and "message" in response["log"]["error"]
+        and "retryable" in response["log"]["error"]
+    )
+
+
 def test_single_prompt(tlm: TLM) -> None:
     """Tests running a single prompt in the TLM.
 
@@ -140,4 +155,4 @@ def test_batch_try_prompt_force_timeouts(tlm: TLM) -> None:
     # - no exceptions are raised (implicit)
     assert response is not None
     assert isinstance(response, list)
-    assert all(r is None for r in response)
+    assert all(is_tlm_response_with_error(r) for r in response)

--- a/tests/tlm/test_prompt.py
+++ b/tests/tlm/test_prompt.py
@@ -156,3 +156,10 @@ def test_batch_try_prompt_force_timeouts(tlm: TLM) -> None:
     assert response is not None
     assert isinstance(response, list)
     assert all(is_tlm_response_with_error(r) for r in response)
+
+
+@pytest.fixture(autouse=True)
+def reset_tlm(tlm):
+    original_timeout = tlm._timeout
+    yield
+    tlm._timeout = original_timeout

--- a/tests/tlm/test_properties.py
+++ b/tests/tlm/test_properties.py
@@ -8,7 +8,9 @@ from cleanlab_studio.internal.constants import (
     _VALID_TLM_QUALITY_PRESETS,
 )
 from cleanlab_studio.studio.trustworthy_language_model import TLM
-from tests.tlm.test_get_trustworthiness_score import is_trustworthiness_score_json_format
+from tests.tlm.test_get_trustworthiness_score import (
+    is_trustworthiness_score_json_format,
+)
 from tests.tlm.test_prompt import is_tlm_response
 
 excluded_tlm_models = ["claude-3-sonnet", "claude-3.5-sonnet"]
@@ -249,5 +251,11 @@ def test_try_get_trustworithness_score(
     responses = tlm.try_get_trustworthiness_score(
         ["What is the capital of France?", "What is the capital of Ukraine?"], ["USA", "Kyiv"]
     )
+<<<<<<< HEAD
     assert all(response is None or is_trustworthiness_score_json_format(response) for response in responses)
+=======
+    assert all(
+        response is None or is_trustworthiness_score_json_format(response) for response in responses
+    )
+>>>>>>> fd8eaa4 (format and update test)
     _test_batch_get_trustworthiness_score_response(responses, options)

--- a/tests/tlm/test_properties.py
+++ b/tests/tlm/test_properties.py
@@ -77,10 +77,7 @@ def _test_batch_prompt_response(
 def _test_get_trustworthiness_score_response(response, options):
     """Property tests the responses of a get_trustworthiness_score based on the options dictionary and returned responses."""
     assert response is not None
-    if "log" in options:
-        assert isinstance(response, dict)
-    else:
-        assert isinstance(response, float)
+    assert isinstance(response, dict)
     assert is_trustworthiness_score_json_format(response)
     _test_log(response, options)
 

--- a/tests/tlm/test_properties.py
+++ b/tests/tlm/test_properties.py
@@ -8,7 +8,7 @@ from cleanlab_studio.internal.constants import (
     _VALID_TLM_QUALITY_PRESETS,
 )
 from cleanlab_studio.studio.trustworthy_language_model import TLM
-from tests.tlm.test_get_trustworthiness_score import is_trustworthiness_score
+from tests.tlm.test_get_trustworthiness_score import is_trustworthiness_score_json_format
 from tests.tlm.test_prompt import is_tlm_response
 
 excluded_tlm_models = ["claude-3-sonnet", "claude-3.5-sonnet"]
@@ -79,7 +79,7 @@ def _test_get_trustworthiness_score_response(response, options):
         assert isinstance(response, dict)
     else:
         assert isinstance(response, float)
-    assert is_trustworthiness_score(response)
+    assert is_trustworthiness_score_json_format(response)
     _test_log(response, options)
 
 
@@ -203,7 +203,7 @@ def test_get_trustworthiness_score(
     responses = tlm.get_trustworthiness_score(
         ["What is the capital of France?", "What is the capital of Ukraine?"], ["USA", "Kyiv"]
     )
-    assert all(is_trustworthiness_score(response) for response in responses)
+    assert all(is_trustworthiness_score_json_format(response) for response in responses)
     _test_batch_get_trustworthiness_score_response(responses, options)
 
 
@@ -231,7 +231,7 @@ def test_get_trustworthiness_score_async(
             ["USA", "Kyiv"],
         )
     )
-    assert all(is_trustworthiness_score(response) for response in responses)
+    assert all(is_trustworthiness_score_json_format(response) for response in responses)
     _test_batch_get_trustworthiness_score_response(responses, options)
 
 
@@ -249,5 +249,5 @@ def test_try_get_trustworithness_score(
     responses = tlm.try_get_trustworthiness_score(
         ["What is the capital of France?", "What is the capital of Ukraine?"], ["USA", "Kyiv"]
     )
-    assert all(response is None or is_trustworthiness_score(response) for response in responses)
+    assert all(response is None or is_trustworthiness_score_json_format(response) for response in responses)
     _test_batch_get_trustworthiness_score_response(responses, options)

--- a/tests/tlm/test_properties.py
+++ b/tests/tlm/test_properties.py
@@ -251,11 +251,7 @@ def test_try_get_trustworithness_score(
     responses = tlm.try_get_trustworthiness_score(
         ["What is the capital of France?", "What is the capital of Ukraine?"], ["USA", "Kyiv"]
     )
-<<<<<<< HEAD
-    assert all(response is None or is_trustworthiness_score_json_format(response) for response in responses)
-=======
     assert all(
         response is None or is_trustworthiness_score_json_format(response) for response in responses
     )
->>>>>>> fd8eaa4 (format and update test)
     _test_batch_get_trustworthiness_score_response(responses, options)

--- a/tests/tlm/test_validation.py
+++ b/tests/tlm/test_validation.py
@@ -1,9 +1,14 @@
+from typing import Any
+
 import numpy as np
 import pytest
 
 from cleanlab_studio.errors import TlmBadRequest, ValidationError
 from cleanlab_studio.studio.studio import Studio
 from cleanlab_studio.studio.trustworthy_language_model import TLM
+
+from .test_get_trustworthiness_score import is_valid_tlm_score_response_with_error
+from .test_prompt import is_tlm_response_with_error
 
 np.random.seed(0)
 
@@ -15,12 +20,63 @@ MAX_COMBINED_LENGTH_TOKENS: int = 70_000
 CHARACTERS_PER_TOKEN: int = 4
 
 
+def assert_prompt_too_long_error(response: Any, index: int):
+    assert is_tlm_response_with_error(response)
+    assert response["log"]["error"]["message"].startswith(
+        f"Error executing query at index {index}:"
+    )
+    assert (
+        "Prompt length exceeds maximum length of 70000 tokens"
+        in response["log"]["error"]["message"]
+    )
+    assert response["log"]["error"]["retryable"] is False
+
+
+def assert_prompt_too_long_error_score(response: Any, index: int):
+    assert is_valid_tlm_score_response_with_error(response)
+    assert response["log"]["error"]["message"].startswith(
+        f"Error executing query at index {index}:"
+    )
+    assert (
+        "Prompt length exceeds maximum length of 70000 tokens"
+        in response["log"]["error"]["message"]
+    )
+    assert response["log"]["error"]["retryable"] is False
+
+
+def assert_response_too_long_error_score(response: Any, index: int):
+    assert is_valid_tlm_score_response_with_error(response)
+    assert response["log"]["error"]["message"].startswith(
+        f"Error executing query at index {index}:"
+    )
+    assert (
+        "Response length exceeds maximum length of 15000 tokens"
+        in response["log"]["error"]["message"]
+    )
+    assert response["log"]["error"]["retryable"] is False
+
+
+def assert_prompt_and_response_combined_too_long_error_score(response: Any, index: int):
+    assert is_valid_tlm_score_response_with_error(response)
+    assert response["log"]["error"]["message"].startswith(
+        f"Error executing query at index {index}:"
+    )
+    assert (
+        "Prompt and response combined length exceeds maximum combined length of 70000 tokens"
+        in response["log"]["error"]["message"]
+    )
+    assert response["log"]["error"]["retryable"] is False
+
+
 def test_prompt_too_long_exception_single_prompt(tlm: TLM):
     """Tests that bad request error is raised when prompt is too long when calling tlm.prompt with a single prompt."""
-    with pytest.raises(TlmBadRequest, match="^Prompt length exceeds.*"):
+    with pytest.raises(TlmBadRequest) as exc_info:
         tlm.prompt(
             "a" * (MAX_PROMPT_LENGTH_TOKENS + 1) * CHARACTERS_PER_TOKEN,
         )
+
+    assert exc_info.value.message.startswith("Prompt length exceeds")
+    assert exc_info.value.retryable is False
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
@@ -34,13 +90,14 @@ def test_prompt_too_long_exception_batch_prompt(tlm: TLM, num_prompts: int):
     prompt_too_long_index = np.random.randint(0, num_prompts)
     prompts[prompt_too_long_index] = "a" * (MAX_PROMPT_LENGTH_TOKENS + 1) * CHARACTERS_PER_TOKEN
 
-    with pytest.raises(
-        TlmBadRequest,
-        match=f"^Error executing query at index {prompt_too_long_index}:\nPrompt length exceeds.*",
-    ):
-        tlm.prompt(
-            prompts,
-        )
+    with pytest.raises(TlmBadRequest) as exc_info:
+        tlm.prompt(prompts)
+
+    assert exc_info.value.message.startswith(
+        f"Error executing query at index {prompt_too_long_index}:"
+    )
+    assert "Prompt length exceeds" in exc_info.value.message
+    assert exc_info.value.retryable is False
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
@@ -55,17 +112,19 @@ def test_prompt_too_long_exception_try_prompt(tlm: TLM, num_prompts: int):
         prompts,
     )
 
-    # assert -- None is returned at correct index
-    assert tlm_responses[prompt_too_long_index] is None
+    assert_prompt_too_long_error(tlm_responses[prompt_too_long_index], prompt_too_long_index)
 
 
 def test_response_too_long_exception_single_score(tlm: TLM):
     """Tests that bad request error is raised when response is too long when calling tlm.get_trustworthiness_score with a single prompt."""
-    with pytest.raises(TlmBadRequest, match="^Response length exceeds.*"):
+    with pytest.raises(TlmBadRequest) as exc_info:
         tlm.get_trustworthiness_score(
             "a",
             "a" * (MAX_RESPONSE_LENGTH_TOKENS + 1) * CHARACTERS_PER_TOKEN,
         )
+
+    assert exc_info.value.message.startswith("Response length exceeds")
+    assert exc_info.value.retryable is False
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
@@ -82,14 +141,17 @@ def test_response_too_long_exception_batch_score(tlm: TLM, num_prompts: int):
         "a" * (MAX_RESPONSE_LENGTH_TOKENS + 1) * CHARACTERS_PER_TOKEN
     )
 
-    with pytest.raises(
-        TlmBadRequest,
-        match=f"^Error executing query at index {response_too_long_index}:\nResponse length exceeds.*",
-    ):
+    with pytest.raises(TlmBadRequest) as exc_info:
         tlm.get_trustworthiness_score(
             prompts,
             responses,
         )
+
+    assert exc_info.value.message.startswith(
+        f"Error executing query at index {response_too_long_index}:"
+    )
+    assert "Response length exceeds" in exc_info.value.message
+    assert exc_info.value.retryable is False
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
@@ -108,17 +170,21 @@ def test_response_too_long_exception_try_score(tlm: TLM, num_prompts: int):
         responses,
     )
 
-    # assert -- None is returned at correct index
-    assert tlm_responses[response_too_long_index] is None
+    assert_response_too_long_error_score(
+        tlm_responses[response_too_long_index], response_too_long_index
+    )
 
 
 def test_prompt_too_long_exception_single_score(tlm: TLM):
     """Tests that bad request error is raised when prompt is too long when calling tlm.get_trustworthiness_score with a single prompt."""
-    with pytest.raises(TlmBadRequest, match="^Prompt length exceeds.*"):
+    with pytest.raises(TlmBadRequest) as exc_info:
         tlm.get_trustworthiness_score(
             "a" * (MAX_PROMPT_LENGTH_TOKENS + 1) * CHARACTERS_PER_TOKEN,
             "a",
         )
+
+    assert exc_info.value.message.startswith("Prompt length exceeds")
+    assert exc_info.value.retryable is False
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
@@ -133,14 +199,17 @@ def test_prompt_too_long_exception_batch_score(tlm: TLM, num_prompts: int):
     prompt_too_long_index = np.random.randint(0, num_prompts)
     prompts[prompt_too_long_index] = "a" * (MAX_PROMPT_LENGTH_TOKENS + 1) * CHARACTERS_PER_TOKEN
 
-    with pytest.raises(
-        TlmBadRequest,
-        match=f"^Error executing query at index {prompt_too_long_index}:\nPrompt length exceeds.*",
-    ):
+    with pytest.raises(TlmBadRequest) as exc_info:
         tlm.get_trustworthiness_score(
             prompts,
             responses,
         )
+
+    assert exc_info.value.message.startswith(
+        f"Error executing query at index {prompt_too_long_index}:"
+    )
+    assert "Prompt length exceeds" in exc_info.value.message
+    assert exc_info.value.retryable is False
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
@@ -157,23 +226,25 @@ def test_prompt_too_long_exception_try_score(tlm: TLM, num_prompts: int):
         responses,
     )
 
-    # assert -- None is returned at correct index
-    assert responses[prompt_too_long_index] is None
+    assert_prompt_too_long_error_score(responses[prompt_too_long_index], prompt_too_long_index)
 
 
 def test_combined_too_long_exception_single_score(tlm: TLM):
     """Tests that bad request error is raised when prompt + response combined length is too long when calling tlm.get_trustworthiness_score with a single prompt."""
     max_prompt_length = MAX_COMBINED_LENGTH_TOKENS - MAX_RESPONSE_LENGTH_TOKENS + 1
 
-    with pytest.raises(TlmBadRequest, match="^Prompt and response combined length exceeds.*"):
+    with pytest.raises(TlmBadRequest) as exc_info:
         tlm.get_trustworthiness_score(
             "a" * max_prompt_length * CHARACTERS_PER_TOKEN,
             "a" * MAX_RESPONSE_LENGTH_TOKENS * CHARACTERS_PER_TOKEN,
         )
 
+    assert exc_info.value.message.startswith("Prompt and response combined length exceeds")
+    assert exc_info.value.retryable is False
+
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
-def test_prompt_too_long_exception_batch_score(tlm: TLM, num_prompts: int):
+def test_prompt_and_response_combined_too_long_exception_batch_score(tlm: TLM, num_prompts: int):
     """Tests that bad request error is raised when prompt + response combined length is too long when calling tlm.get_trustworthiness_score with a batch of prompts.
 
     Error message should indicate which the batch index for which the prompt is too long.
@@ -187,37 +258,35 @@ def test_prompt_too_long_exception_batch_score(tlm: TLM, num_prompts: int):
     prompts[combined_too_long_index] = "a" * max_prompt_length * CHARACTERS_PER_TOKEN
     responses[combined_too_long_index] = "a" * MAX_RESPONSE_LENGTH_TOKENS * CHARACTERS_PER_TOKEN
 
-    with pytest.raises(
-        TlmBadRequest,
-        match=f"^Error executing query at index {combined_too_long_index}:\nPrompt and response combined length exceeds.*",
-    ):
-        tlm.get_trustworthiness_score(
-            prompts,
-            responses,
-        )
+    tlm_responses = tlm.try_get_trustworthiness_score(
+        prompts,
+        responses,
+    )
+
+    assert_prompt_and_response_combined_too_long_error_score(
+        tlm_responses[combined_too_long_index], combined_too_long_index
+    )
 
 
 @pytest.mark.parametrize("num_prompts", [1, 2, 5])
-def test_prompt_too_long_exception_try_score(tlm: TLM, num_prompts: int):
-    """Tests that None is returned when prompt + response is too long when calling tlm.try_get_trustworthiness_score with a batch of prompts."""
+def test_prompt_and_response_combined_too_long_exception_try_score(tlm: TLM, num_prompts: int):
+    """Tests that appropriate error is returned when prompt + response is too long when calling tlm.try_get_trustworthiness_score with a batch of prompts."""
     # create batch of prompts with one prompt that is too long
     prompts = ["What is the capital of France?"] * num_prompts
     responses = ["Paris"] * num_prompts
     combined_too_long_index = np.random.randint(0, num_prompts)
-    prompts[combined_too_long_index] = (
-        "a" * (MAX_PROMPT_LENGTH_TOKENS // 2 + 1) * CHARACTERS_PER_TOKEN
-    )
-    responses[combined_too_long_index] = (
-        "a" * (MAX_PROMPT_LENGTH_TOKENS // 2 + 1) * CHARACTERS_PER_TOKEN
-    )
+    max_prompt_length = MAX_COMBINED_LENGTH_TOKENS - MAX_RESPONSE_LENGTH_TOKENS + 1
+    prompts[combined_too_long_index] = "a" * max_prompt_length * CHARACTERS_PER_TOKEN
+    responses[combined_too_long_index] = "a" * MAX_RESPONSE_LENGTH_TOKENS * CHARACTERS_PER_TOKEN
 
     responses = tlm.try_get_trustworthiness_score(
         prompts,
         responses,
     )
 
-    # assert -- None is returned at correct index
-    assert responses[combined_too_long_index] is None
+    assert_prompt_and_response_combined_too_long_error_score(
+        responses[combined_too_long_index], combined_too_long_index
+    )
 
 
 def test_invalid_option_passed(studio: Studio):

--- a/tests/tlm/test_validation.py
+++ b/tests/tlm/test_validation.py
@@ -7,7 +7,7 @@ from cleanlab_studio.errors import TlmBadRequest, ValidationError
 from cleanlab_studio.studio.studio import Studio
 from cleanlab_studio.studio.trustworthy_language_model import TLM
 
-from .test_get_trustworthiness_score import is_valid_tlm_score_response_with_error
+from .test_get_trustworthiness_score import is_tlm_score_response_with_error
 from .test_prompt import is_tlm_response_with_error
 
 np.random.seed(0)
@@ -33,7 +33,7 @@ def assert_prompt_too_long_error(response: Any, index: int):
 
 
 def assert_prompt_too_long_error_score(response: Any, index: int):
-    assert is_valid_tlm_score_response_with_error(response)
+    assert is_tlm_score_response_with_error(response)
     assert response["log"]["error"]["message"].startswith(
         f"Error executing query at index {index}:"
     )
@@ -45,7 +45,7 @@ def assert_prompt_too_long_error_score(response: Any, index: int):
 
 
 def assert_response_too_long_error_score(response: Any, index: int):
-    assert is_valid_tlm_score_response_with_error(response)
+    assert is_tlm_score_response_with_error(response)
     assert response["log"]["error"]["message"].startswith(
         f"Error executing query at index {index}:"
     )
@@ -57,7 +57,7 @@ def assert_response_too_long_error_score(response: Any, index: int):
 
 
 def assert_prompt_and_response_combined_too_long_error_score(response: Any, index: int):
-    assert is_valid_tlm_score_response_with_error(response)
+    assert is_tlm_score_response_with_error(response)
     assert response["log"]["error"]["message"].startswith(
         f"Error executing query at index {index}:"
     )


### PR DESCRIPTION
Changes:

- This is a backwards incompatible change so bumped the major version
- All the score related functions only return TLMScore objects. When it’s a successful call and no log is returned, it will be a single “trustworthiness_score” field inside the json
- Both the try_prompt() and try_get_trustworthiness_score() will no longer return None
- Changed tlm_lite in the same format as well
- In addition to the final error log output, we also raise warning to the user as well so they can be aware of

Tests:
https://drive.google.com/file/d/1v-pBme_ENiUObEnAaxdi9fmQyVR2lJyc/view?usp=drive_link 
