### PR TITLE
[TLM CI] update how pr/issue numbers are handled

### DIFF
--- a/.github/workflows/ci-tlm.yml
+++ b/.github/workflows/ci-tlm.yml
@@ -86,7 +86,7 @@ jobs:
         id: fc
         uses: peter-evans/find-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.issue.number }}
           body-regex: '^/test-tlm$'
           direction: last
       - name: Update comment
@@ -111,7 +111,7 @@ jobs:
         id: fc
         uses: peter-evans/find-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.issue.number }}
           body-includes: Starting TLM tests
           direction: last
       - name: Build Comment Body


### PR DESCRIPTION
If a workflow is launched through a pull_request action, using github.event.pull_request.number to get the pr number [works great](https://github.com/cleanlab/cleanlab-studio/actions/runs/10835062351/job/30065723879?pr=303). However, [this does not seem to be true](https://github.com/cleanlab/cleanlab-studio/actions/runs/10835079271/job/30065780786) for a workflow launched through a comment action.

Bugfix attempt to use github.event.issue.number instead (since pr/issue number is the same value)