### PR TITLE
TLM constrain_outputs doc

### DIFF
--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -384,11 +384,11 @@ class TLM:
         Args:
             prompt (str | Sequence[str]): prompt (or list of multiple prompts) for the language model.
                 Providing a batch of many prompts here will be faster than calling this method on each prompt separately.
-            **kwargs: Optional keyword arguments to pass to the underlying TLM object. Currently, only `constrain_outputs` is supported.
-                `constrain_outputs` is a list of strings or a list of lists of strings.
-                If a list of strings is provided, each prompt will be constrained to one of the strings in the list.
-                If a list of lists of strings is provided, each prompt will be constrained to one of the strings in the corresponding list.
-                If `constrain_outputs` is not provided, the TLM will not constrain the output.
+            **kwargs: Optional keyword arguments for TLM. When using TLM for multi-class classification, specify `constrain_outputs` as a keyword argument to ensure returned responses are one of the valid classes/categories.
+                `constrain_outputs` is a list of strings (or a list of lists of strings), used to denote the valid classes/categories of interest.
+                We recommend also listing and defining the valid outputs in your prompt as well.
+                If `constrain_outputs` is a list of strings, the response returned for every prompt will be constrained to match one of these values. The last entry in this list is additionally treated as the output to fall back to if the raw LLM output does not resemble any of the categories (for instance, this could be an Other category, or it could be the category you'd prefer to return whenever the LLM is unsure).
+                If you run a list of multiple prompts simultaneously and want to differently constrain each of their outputs, then specify `constrain_outputs` as a list of lists of strings (one list for each prompt).
         Returns:
             TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and trustworthiness score.
                 If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -384,7 +384,7 @@ class TLM:
         Args:
             prompt (str | Sequence[str]): prompt (or list of multiple prompts) for the language model.
                 Providing a batch of many prompts here will be faster than calling this method on each prompt separately.
-            **kwargs: Optional keyword arguments for TLM. When using TLM for multi-class classification, specify `constrain_outputs` as a keyword argument to ensure returned responses are one of the valid classes/categories.
+            kwargs: Optional keyword arguments for TLM. When using TLM for multi-class classification, specify `constrain_outputs` as a keyword argument to ensure returned responses are one of the valid classes/categories.
                 `constrain_outputs` is a list of strings (or a list of lists of strings), used to denote the valid classes/categories of interest.
                 We recommend also listing and defining the valid outputs in your prompt as well.
                 If `constrain_outputs` is a list of strings, the response returned for every prompt will be constrained to match one of these values. The last entry in this list is additionally treated as the output to fall back to if the raw LLM output does not resemble any of the categories (for instance, this could be an Other category, or it could be the category you'd prefer to return whenever the LLM is unsure).
@@ -440,11 +440,11 @@ class TLM:
 
         Args:
             prompt (Sequence[str]): list of multiple prompts for the TLM
-            **kwargs: Optional keyword arguments to pass to the underlying TLM object. Currently, only `constrain_outputs` is supported.
-                `constrain_outputs` is a list of strings or a list of lists of strings.
-                If a list of strings is provided, each prompt will be constrained to one of the strings in the list.
-                If a list of lists of strings is provided, each prompt will be constrained to one of the strings in the corresponding list.
-                If `constrain_outputs` is not provided, the TLM will not constrain the output.
+            kwargs: Optional keyword arguments for TLM. When using TLM for multi-class classification, specify `constrain_outputs` as a keyword argument to ensure returned responses are one of the valid classes/categories.
+                `constrain_outputs` is a list of strings (or a list of lists of strings), used to denote the valid classes/categories of interest.
+                We recommend also listing and defining the valid outputs in your prompt as well.
+                If `constrain_outputs` is a list of strings, the response returned for every prompt will be constrained to match one of these values. The last entry in this list is additionally treated as the output to fall back to if the raw LLM output does not resemble any of the categories (for instance, this could be an Other category, or it could be the category you'd prefer to return whenever the LLM is unsure).
+                If you run a list of multiple prompts simultaneously and want to differently constrain each of their outputs, then specify `constrain_outputs` as a list of lists of strings (one list for each prompt).
         Returns:
             List[TLMResponse]: list of [TLMResponse](#class-tlmresponse) objects containing the response and trustworthiness score.
                 The returned list will always have the same length as the input list.
@@ -482,11 +482,11 @@ class TLM:
 
         Args:
             prompt (str | Sequence[str]): prompt (or list of multiple prompts) for the TLM
-            **kwargs: Optional keyword arguments to pass to the underlying TLM object. Currently, only `constrain_outputs` is supported.
-                `constrain_outputs` is a list of strings or a list of lists of strings.
-                If a list of strings is provided, each prompt will be constrained to one of the strings in the list.
-                If a list of lists of strings is provided, each prompt will be constrained to one of the strings in the corresponding list.
-                If `constrain_outputs` is not provided, the TLM will not constrain the output.
+            kwargs: Optional keyword arguments for TLM. When using TLM for multi-class classification, specify `constrain_outputs` as a keyword argument to ensure returned responses are one of the valid classes/categories.
+                `constrain_outputs` is a list of strings (or a list of lists of strings), used to denote the valid classes/categories of interest.
+                We recommend also listing and defining the valid outputs in your prompt as well.
+                If `constrain_outputs` is a list of strings, the response returned for every prompt will be constrained to match one of these values. The last entry in this list is additionally treated as the output to fall back to if the raw LLM output does not resemble any of the categories (for instance, this could be an Other category, or it could be the category you'd prefer to return whenever the LLM is unsure).
+                If you run a list of multiple prompts simultaneously and want to differently constrain each of their outputs, then specify `constrain_outputs` as a list of lists of strings (one list for each prompt).
         Returns:
             TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and trustworthiness score.
                 If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.

--- a/cleanlab_studio/studio/trustworthy_language_model.py
+++ b/cleanlab_studio/studio/trustworthy_language_model.py
@@ -384,6 +384,11 @@ class TLM:
         Args:
             prompt (str | Sequence[str]): prompt (or list of multiple prompts) for the language model.
                 Providing a batch of many prompts here will be faster than calling this method on each prompt separately.
+            **kwargs: Optional keyword arguments to pass to the underlying TLM object. Currently, only `constrain_outputs` is supported.
+                `constrain_outputs` is a list of strings or a list of lists of strings.
+                If a list of strings is provided, each prompt will be constrained to one of the strings in the list.
+                If a list of lists of strings is provided, each prompt will be constrained to one of the strings in the corresponding list.
+                If `constrain_outputs` is not provided, the TLM will not constrain the output.
         Returns:
             TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and trustworthiness score.
                 If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.
@@ -435,6 +440,11 @@ class TLM:
 
         Args:
             prompt (Sequence[str]): list of multiple prompts for the TLM
+            **kwargs: Optional keyword arguments to pass to the underlying TLM object. Currently, only `constrain_outputs` is supported.
+                `constrain_outputs` is a list of strings or a list of lists of strings.
+                If a list of strings is provided, each prompt will be constrained to one of the strings in the list.
+                If a list of lists of strings is provided, each prompt will be constrained to one of the strings in the corresponding list.
+                If `constrain_outputs` is not provided, the TLM will not constrain the output.
         Returns:
             List[TLMResponse]: list of [TLMResponse](#class-tlmresponse) objects containing the response and trustworthiness score.
                 The returned list will always have the same length as the input list.
@@ -472,6 +482,11 @@ class TLM:
 
         Args:
             prompt (str | Sequence[str]): prompt (or list of multiple prompts) for the TLM
+            **kwargs: Optional keyword arguments to pass to the underlying TLM object. Currently, only `constrain_outputs` is supported.
+                `constrain_outputs` is a list of strings or a list of lists of strings.
+                If a list of strings is provided, each prompt will be constrained to one of the strings in the list.
+                If a list of lists of strings is provided, each prompt will be constrained to one of the strings in the corresponding list.
+                If `constrain_outputs` is not provided, the TLM will not constrain the output.
         Returns:
             TLMResponse | List[TLMResponse]: [TLMResponse](#class-tlmresponse) object containing the response and trustworthiness score.
                 If multiple prompts were provided in a list, then a list of such objects is returned, one for each prompt.

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.5.9"
+__version__ = "2.5.10"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
<img width="673" alt="Screenshot 2025-01-08 at 2 33 52 PM" src="https://github.com/user-attachments/assets/8e440e57-0805-4eda-8f1d-68b295dbe2ef" />


Note that the ** is intentionally removed in the docstring to avoid inappropriate rendering like below
<img width="651" alt="Screenshot 2025-01-08 at 2 34 35 PM" src="https://github.com/user-attachments/assets/36c57538-cc43-4f76-a75e-e4f246cff6fb" />
