### PR TITLE
[TLM] constrain output batch prompt update

### DIFF
--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -26,6 +26,7 @@ _TLM_MAX_TOKEN_RANGE: Dict[str, Tuple[int, int]] = {  # model: (min, max)
     "claude-3.5-haiku": (64, 512),
     "claude-3-sonnet": (64, 512),
     "claude-3.5-sonnet": (64, 512),
+    "nova-micro": (64, 512),
 }
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: Tuple[int, int] = (1, 20)  # (min, max)
 TLM_NUM_CONSISTENCY_SAMPLES_RANGE: Tuple[int, int] = (0, 20)  # (min, max)

--- a/cleanlab_studio/internal/constants.py
+++ b/cleanlab_studio/internal/constants.py
@@ -23,6 +23,7 @@ _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 _TLM_MAX_TOKEN_RANGE: Dict[str, Tuple[int, int]] = {  # model: (min, max)
     "default": (64, 4096),
     "claude-3-haiku": (64, 512),
+    "claude-3.5-haiku": (64, 512),
     "claude-3-sonnet": (64, 512),
     "claude-3.5-sonnet": (64, 512),
 }

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -40,11 +40,24 @@ def validate_tlm_prompt_kwargs_constrain_outputs(
             ):
                 raise ValidationError("constrain_outputs must be a list of strings")
         elif isinstance(prompt, Sequence):
-            if not isinstance(constrain_outputs, list) or not all(
+            if not isinstance(constrain_outputs, list):
+                raise ValidationError("constrain_outputs must be a list")
+
+            # If it's a list of strings, repeat the list for each prompt
+            if all(isinstance(co, str) for co in constrain_outputs):
+                constrain_outputs = [constrain_outputs] * len(prompt)
+                pass
+            # Check if it's a list of lists of strings
+            elif all(
                 isinstance(co, list) and all(isinstance(s, str) for s in co)
                 for co in constrain_outputs
             ):
-                raise ValidationError("constrain_outputs must be a list of lists of strings")
+                pass
+            else:
+                raise ValidationError(
+                    "constrain_outputs must be a list of strings or a list of lists of strings"
+                )
+
             if len(constrain_outputs) != len(prompt):
                 raise ValidationError("constrain_outputs must have same length as prompt")
 

--- a/cleanlab_studio/internal/tlm/validation.py
+++ b/cleanlab_studio/internal/tlm/validation.py
@@ -46,7 +46,6 @@ def validate_tlm_prompt_kwargs_constrain_outputs(
             # If it's a list of strings, repeat the list for each prompt
             if all(isinstance(co, str) for co in constrain_outputs):
                 constrain_outputs = [constrain_outputs] * len(prompt)
-                pass
             # Check if it's a list of lists of strings
             elif all(
                 isinstance(co, list) and all(isinstance(s, str) for s in co)

--- a/cleanlab_studio/version.py
+++ b/cleanlab_studio/version.py
@@ -1,7 +1,7 @@
 # Note to developers:
 # Consider if backend's MIN_CLI_VERSION needs updating when pushing any changes to this file.
 
-__version__ = "2.5.12"
+__version__ = "2.5.13"
 
 SCHEMA_VERSION = "0.2.0"
 MIN_SCHEMA_VERSION = "0.1.0"

--- a/tests/tlm/constants.py
+++ b/tests/tlm/constants.py
@@ -17,6 +17,7 @@ CHARACTERS_PER_TOKEN: int = 4
 
 # Property tests for TLM
 excluded_tlm_models: List[str] = [
+    "claude-3.5-haiku",
     "claude-3-sonnet",
     "claude-3.5-sonnet",
     "claude-3.5-sonnet-v2",

--- a/tests/tlm/test_validation.py
+++ b/tests/tlm/test_validation.py
@@ -96,17 +96,6 @@ def test_prompt_constrain_outputs_wrong_type_single_prompt(tlm: TLM):
     assert str(exc_info.value).startswith("constrain_outputs must be a list of strings")
 
 
-def test_prompt_constrain_outputs_wrong_type_batch_prompt(tlm: TLM):
-    """Tests that validation error is raised when constrain_outputs is not a list of lists of strings when prompt is a list of strings."""
-    with pytest.raises(ValidationError) as exc_info:
-        tlm.prompt(
-            ["test prompt"],
-            constrain_outputs=["test constrain outputs"],
-        )
-
-    assert str(exc_info.value).startswith("constrain_outputs must be a list of lists of strings")
-
-
 def test_prompt_constrain_outputs_wrong_length(tlm: TLM):
     """Tests that validation error is raised when constrain_outputs length does not match prompt length."""
     with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
Have `constrain_outputs` to support single list of strings for batch prompt use cases.