### PR TITLE
Allow Click 8.1.7+ for langchain etc compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "aiohttp>=3.8.1",
-        "Click>=8.1.0,<=8.1.3",
+        "Click>=8.1.0,<8.2.0",
         "colorama>=0.4.4",
         "nest_asyncio>=1.5.0",
         "pandas==2.*",


### PR DESCRIPTION
Closes https://github.com/cleanlab/cleanlab-studio/issues/347
Allowing Click 8.1.7 and later fixes compatibility with packages like langchain that require later Click 8.1.x versions.